### PR TITLE
Get ReadTheDocs working

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+archspec

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,8 @@ extensions = [
     'sphinx.ext.napoleon'
 ]
 
+master_doc = 'index'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Read the Docs uses an old version of Sphinx, so we need to add:
```
master_doc = 'index'
```
otherwise Sphinx will look for `contents.rst` instead of `index.rst`. 

Also, installing `archspec` via `pip` as a fast solution to have APIs documented with `autodoc`. Later it would be advisable to integrate `poetry` into Sphinx build on RTD.