### PR TITLE
also run tests with Python 2.7 and for branches other than master

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,12 +15,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
       matrix:
         os:
           - ubuntu-latest
           - macos-latest
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
* `2.7` is listed in `tox.ini`, but not in the GitHub Actions workflow, so we were not testing with Python 2.7 in CI
* I see no reason to only test in `master` (I find it really easy to test in my own fork first before opening a PR for example)
* I see no reason for limited maximum test jobs running in parallel to just 4?