### PR TITLE
Added Read the Docs links to README and PyPI description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![](https://github.com/archspec/archspec/workflows/Unit%20tests/badge.svg)](https://github.com/archspec/archspec/actions)
 [![codecov](https://codecov.io/gh/archspec/archspec/branch/master/graph/badge.svg)](https://codecov.io/gh/archspec/archspec)
+[![Documentation Status](https://readthedocs.org/projects/archspec/badge/?version=latest)](https://archspec.readthedocs.io/en/latest/?badge=latest)
 
 
 # Archspec (Python bindings)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -58,10 +58,10 @@ started using it.
 .. TODO: Recommend using ``pip``?
 
 ---------------------------------
-Installing from Github Repository
+Installing from GitHub Repository
 ---------------------------------
 
-Installing Archspec from a clone of its Github Repository
+Installing Archspec from a clone of its GitHub Repository
 requires `poetry <https://python-poetry.org/>`_. The
 preferred method to install this tool is via
 its custom installer outside of any virtual environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ maintainers = [
 ]
 repository = "https://github.com/archspec/archspec.git"
 homepage = "https://github.com/archspec/archspec"
+documentation = "https://archspec.readthedocs.io"
 readme = "README.md"
 classifiers = [
 "Development Status :: 3 - Alpha",


### PR DESCRIPTION
I presume that adding the link to `pyproject.toml` will add it to [the PyPI project page](https://pypi.org/project/archspec/) sidebar [per](https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls) `project_urls`.