### PR TITLE
Pinning virtualenv version since 20.X is causing test failures

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (Common)
       run: |
-        pip install poetry tox-gh-actions coverage
+        pip install poetry tox-gh-actions coverage virtualenv==16.7.9
     - name: Run tests with tox
       run: |
         tox

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (Common)
+      # For the virtualenv installation see https://github.com/tox-dev/tox/issues/1516
       run: |
         pip install poetry tox-gh-actions coverage virtualenv==16.7.9
     - name: Run tests with tox


### PR DESCRIPTION
See https://github.com/tox-dev/tox/issues/1516