### PR TITLE
Revert "Pinning virtualenv version since 20.X is causing test failures"

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,9 +31,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (Common)
-      # For the virtualenv installation see https://github.com/tox-dev/tox/issues/1516
       run: |
-        pip install poetry tox-gh-actions coverage virtualenv==16.7.9
+        pip install poetry tox-gh-actions coverage
     - name: Run tests with tox
       run: |
         tox


### PR DESCRIPTION
This reverts commit 22ded1ea36adc69cc7afa201a364bc3515f79d8e.

Keeping this here to check when `virtualenv` gets fixed.