### PR TITLE
don't just trigger CI tests on master branch

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,11 +2,7 @@ name: Unit tests
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches: 
-      - master
   schedule:
   - cron: "0 4 * * *"
     


### PR DESCRIPTION
fleshed out from #4, I still think this is a good idea, makes it easy for people to verify their changes with CI in GitHub without having to set up everything locally (and these tests are quite cheap, it's not like GitHub will notice those few extra runs...)