### PR TITLE
kickstart 'archspec' command line interface

### DIFF
--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -14,14 +14,9 @@ def main():
     """archspec command line interface"""
 
 
-@main.group()
+@main.command()
 def cpu():
     """archspec command line interface for CPU"""
-
-
-@cpu.command()
-def host():
-    """print name of CPU microarchitecture of host"""
     click.echo(archspec.cpu.host())
 
 

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -2,31 +2,25 @@
 
 import archspec
 import archspec.cpu
-import argparse
-import sys
+import click
 
 
+@click.group(name='archspec')
 def main():
-    parser = argparse.ArgumentParser(description="archspec command line interface",
-                                     prog='archspec')
-    parser.add_argument('-V', '--version', action='version', version=archspec.__version__)
+    """archspec command line interface"""
+    pass
 
-    subparsers = parser.add_subparsers()
 
-    cpu_parser = subparsers.add_parser('cpu')
+@main.group()
+def cpu():
+    """archspec command line interface for CPU"""
+    pass
 
-    cpu_host_parser = cpu_parser.add_subparsers().add_parser('host')
-    cpu_host_parser.add_argument('cpu.host', help="print name of host CPU microarchitecture",
-                                 action='store_true')
 
-    args = parser.parse_args()
-
-    if getattr(args, 'cpu.host'):
-        print(archspec.cpu.host())
-        sys.exit(0)
-    else:
-        parser.print_usage()
-        sys.exit(1)
+@cpu.command()
+def host():
+    """print name of CPU microarchitecture of host"""
+    click.echo(archspec.cpu.host())
 
 
 if __name__ == '__main__':

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import archspec
+import archspec.cpu
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="archspec command line interface", prog='archspec')
+
+    parser.add_argument('--cpu-host', help="Print name of host CPU microarchitecture", action='store_true')
+    parser.add_argument('--version', action='version', version=archspec.__version__)
+
+    args = parser.parse_args()
+
+    if args.cpu_host:
+        print(archspec.cpu.host())
+        sys.exit(0)
+    else:
+        parser.print_usage()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -7,16 +7,21 @@ import sys
 
 
 def main():
-    parser = argparse.ArgumentParser(description="archspec command line interface", 
+    parser = argparse.ArgumentParser(description="archspec command line interface",
                                      prog='archspec')
+    parser.add_argument('-V', '--version', action='version', version=archspec.__version__)
 
-    parser.add_argument('--cpu-host', help="Print name of host CPU microarchitecture",
-                        action='store_true')
-    parser.add_argument('--version', action='version', version=archspec.__version__)
+    subparsers = parser.add_subparsers()
+
+    cpu_parser = subparsers.add_parser('cpu')
+
+    cpu_host_parser = cpu_parser.add_subparsers().add_parser('host')
+    cpu_host_parser.add_argument('cpu.host', help="print name of host CPU microarchitecture",
+                                 action='store_true')
 
     args = parser.parse_args()
 
-    if args.cpu_host:
+    if getattr(args, 'cpu.host'):
         print(archspec.cpu.host())
         sys.exit(0)
     else:

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -9,7 +9,7 @@ import archspec
 import archspec.cpu
 
 
-@click.group(name='archspec')
+@click.group(name="archspec")
 def main():
     """archspec command line interface"""
 
@@ -25,5 +25,5 @@ def host():
     click.echo(archspec.cpu.host())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python
+"""
+archspec command line interface
+"""
+
+import click
 
 import archspec
 import archspec.cpu
-import click
 
 
-@click.group(name="archspec")
+@click.group(name='archspec')
 def main():
     """archspec command line interface"""
-    pass
 
 
 @main.group()
 def cpu():
     """archspec command line interface for CPU"""
-    pass
 
 
 @cpu.command()
@@ -23,5 +25,5 @@ def host():
     click.echo(archspec.cpu.host())
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -5,7 +5,7 @@ import archspec.cpu
 import click
 
 
-@click.group(name='archspec')
+@click.group(name="archspec")
 def main():
     """archspec command line interface"""
     pass
@@ -23,5 +23,5 @@ def host():
     click.echo(archspec.cpu.host())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -7,9 +7,11 @@ import sys
 
 
 def main():
-    parser = argparse.ArgumentParser(description="archspec command line interface", prog='archspec')
+    parser = argparse.ArgumentParser(description="archspec command line interface", 
+                                     prog='archspec')
 
-    parser.add_argument('--cpu-host', help="Print name of host CPU microarchitecture", action='store_true')
+    parser.add_argument('--cpu-host', help="Print name of host CPU microarchitecture",
+                        action='store_true')
     parser.add_argument('--version', action='version', version=archspec.__version__)
 
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "archspec"
-version = "0.1.1"
+version = "0.1.0"
 description = "A library to query system architecture"
 license = "Apache-2.0 OR MIT"
 authors = ["archspec developers <maintainers@spack.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "archspec"
-version = "0.1.0"
+version = "0.1.1"
 description = "A library to query system architecture"
 license = "Apache-2.0 OR MIT"
 authors = ["archspec developers <maintainers@spack.io>"]
@@ -53,6 +53,9 @@ sphinx_rtd_theme = [
   {version = "^0.4.3", python = "^3.5"}
 ]
 jsonschema = "^3.2.0"
+
+[tool.poetry.scripts]
+archspec = 'archspec.cli:main'
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=2.7 !=3.4.* !=3.3.* !=3.2.* !=3.1.* !=3.0.*"
 six = "^1.13.0"
+click = ">=7.1.2,<8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = [


### PR DESCRIPTION
```
$ archspec
usage: archspec [-h] [--cpu-host] [--version]

$ archspec --version
0.1.0

$ archspec --cpu-host
skylake

$ archspec -h
usage: archspec [-h] [--cpu-host] [--version]

archspec command line interface

optional arguments:
  -h, --help  show this help message and exit
  --cpu-host  Print name of host CPU microarchitecture
  --version   show program's version number and exit
```