### PR TITLE
Separate Apple's Clang from LLVM

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -206,9 +206,20 @@ class Microarchitecture(object):
             compiler (str): name of the compiler to be used
             version (str): version of the compiler to be used
         """
-        # If we don't have information on compiler return an empty string
-        if compiler not in self.compilers:
+        # If we don't have information on compiler at all return an empty string
+        if compiler not in self.family.compilers:
             return ""
+
+        # If we have information but it stops before this
+        # microarchitecture, fall back to the best known target
+        if compiler not in self.compilers:
+            best_target = [x for x in self.ancestors if compiler in x.compilers][0]
+            msg = (
+                "'{0}' compiler is known to optimize up to the '{1}'"
+                " microarchitecture in the '{2}' architecture family"
+            )
+            msg = msg.format(compiler, best_target, best_target.family)
+            raise UnsupportedMicroarchitecture(msg)
 
         # If we have information on this compiler we need to check the
         # version being used
@@ -218,15 +229,9 @@ class Microarchitecture(object):
             min_version, max_version = entry["versions"].split(":")
 
             # Check version suffixes
-            min_version, min_suffix = version_components(min_version)
-            max_version, max_suffix = version_components(max_version)
-            version, suffix = version_components(version)
-
-            # If the suffixes are not all equal there's no match
-            if (suffix != min_suffix and min_version) or (
-                suffix != max_suffix and max_version  # pylint: disable=bad-continuation
-            ):
-                return False
+            min_version, _ = version_components(min_version)
+            max_version, _ = version_components(max_version)
+            version, _ = version_components(version)
 
             # Assume compiler versions fit into semver
             tuplify = lambda x: tuple(int(y) for y in x.split("."))  # noqa: E731,E501
@@ -287,7 +292,7 @@ def version_components(version):
     """Decomposes the version passed as input in version number and
     suffix and returns them.
 
-    If the version number of the suffix are not present, an empty
+    If the version number or the suffix are not present, an empty
     string is returned.
 
     Args:

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -234,7 +234,8 @@ class Microarchitecture(object):
             version, _ = version_components(version)
 
             # Assume compiler versions fit into semver
-            tuplify = lambda x: tuple(int(y) for y in x.split("."))  # noqa: E731,E501
+            def tuplify(ver):
+                return tuple(int(y) for y in ver.split("."))
 
             version = tuplify(version)
             if min_version:

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -258,14 +258,12 @@ def test_optimization_flags(target_name, compiler, version, expected_flags):
 
 
 @pytest.mark.parametrize(
-    "target_name,compiler,version", [("excavator", "gcc", "4.8.5")]
+    "target_name,compiler,version",
+    [("excavator", "gcc", "4.8.5"), ("broadwell", "apple-clang", "11.0.0")],
 )
 def test_unsupported_optimization_flags(target_name, compiler, version):
     target = archspec.cpu.TARGETS[target_name]
-    with pytest.raises(
-        archspec.cpu.UnsupportedMicroarchitecture,
-        match="cannot produce optimized binary",
-    ):
+    with pytest.raises(archspec.cpu.UnsupportedMicroarchitecture):
         target.optimization_flags(compiler, version)
 
 

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -220,6 +220,8 @@ def test_target_json_schema():
         ("sandybridge", "gcc", "4.8.5", "-march=corei7-avx -mtune=corei7-avx"),
         ("thunderx2", "gcc", "4.8.5", "-march=armv8-a"),
         ("thunderx2", "gcc", "4.9.3", "-march=armv8-a+crc+crypto"),
+        # Test Apple's Clang
+        ("x86_64", "apple-clang", "11.0.0", "-march=x86-64"),
         # Test Clang / LLVM
         ("sandybridge", "clang", "3.9.0", "-march=sandybridge -mtune=sandybridge"),
         ("icelake", "clang", "6.0.0", "-march=icelake -mtune=icelake"),


### PR DESCRIPTION
Modifications:
- [x] Use the latest JSON file that encodes Apple's Clang as a compiler of its own
- [x] Modify `optimization_flags` logic to account for Apple's Clang