### PR TITLE
Archspec now has its own release number

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,5 @@
-Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-Spack and Archspec Project Developers. See the top-level COPYRIGHT file 
-for details.
+Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+Archspec Project Developers. See the top-level COPYRIGHT file for details.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -7,33 +7,33 @@
 
 Archspec aims at providing a standard set of human-understandable labels for
 various aspects of a system architecture  like CPU, network fabrics, etc. and
-APIs to detect, query and compare them. 
+APIs to detect, query and compare them.
 
-This project grew out of [Spack](https://spack.io/) and is currently under 
-active development. At present it supports APIs to detect and model 
+This project grew out of [Spack](https://spack.io/) and is currently under
+active development. At present it supports APIs to detect and model
 compatibility relationships among different CPU microarchitectures.
 
 ## Getting started with development
 
 The `archspec` Python package needs [poetry](https://python-poetry.org/) to
-be installed from VCS sources. The preferred method to install it is via 
+be installed from VCS sources. The preferred method to install it is via
 its custom installer outside of any virtual environment:
 ```console
 $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-``` 
+```
 You can refer to [Poetry's documentation](https://python-poetry.org/docs/#installation)
 for further details or for other methods to install this tool. You'll also need `tox`
 to run unit test:
 ```console
 $ pip install --user tox
 ```
-Finally you'll need to clone the repository: 
+Finally you'll need to clone the repository:
 ```console
 $ git clone --recursive https://github.com/archspec/archspec.git
 ```
 
 ### Running unit tests
-Once you have your environment ready you can run `archspec` unit tests 
+Once you have your environment ready you can run `archspec` unit tests
 using ``tox`` from the root of the repository:
 ```console
 $ tox
@@ -47,10 +47,9 @@ $ tox
   flake8: commands succeeded
   black: commands succeeded
   congratulations :)
-``` 
+```
 
 ## License
-
 
 Archspec is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0). Users may choose either license, at their
@@ -65,3 +64,5 @@ See [LICENSE-MIT](https://github.com/archspec/archspec/blob/master/LICENSE-MIT),
 [NOTICE](https://github.com/archspec/archspec/blob/master/NOTICE) for details.
 
 SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+LLNL-CODE-811653

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """

--- a/archspec/cpu/__init__.py
+++ b/archspec/cpu/__init__.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """The "cpu" package permits to query and compare different

--- a/archspec/cpu/alias.py
+++ b/archspec/cpu/alias.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Aliases for microarchitecture features."""

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Detection of CPU microarchitectures"""

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Types and functions to manage information

--- a/archspec/cpu/schema.py
+++ b/archspec/cpu/schema.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Global objects with the content of the microarchitecture

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/tests/test_archspec.py
+++ b/tests/test_archspec.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from archspec import __version__

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -1,6 +1,5 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack and Archspec Project Developers. See the top-level COPYRIGHT file
-# for details.
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 


### PR DESCRIPTION
Archspec grew out of Spack, so we initially just labeled it that way, but it's really its own project. I put in a separate code release for Archspec, so now we don't have to mention Spack in all the code headers.

- [x] added the new release number, LLNL-CODE-811653, to `README.md`
- [x] changed all the SPDX headers to only mention archspec
- [x] changed copyright year to start of archspec