### PR TITLE
add support for 'archspec graph'

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,11 +1,11 @@
-name: Unit tests
+name: CLI tests
 
 on:
   push:
   pull_request:
   schedule:
   - cron: "0 4 * * *"
-    
+
 jobs:
   build:
 
@@ -27,13 +27,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (Common)
       run: |
-        pip install poetry tox-gh-actions coverage
-    - name: Run tests with tox
+        pip install poetry
+    - name: Run archspec commands
       run: |
-        tox
-        coverage xml
-    - name: Upload to codecov.io
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
+        poetry install
+        poetry run archspec cpu
+        poetry run archspec graph
+    - name: Render output of archspec graph --dag
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get install graphviz
+        poetry run archspec graph --cpu | dot -T pdf -o archspec_cpu_dag.pdf;
+        ls -l archspec_cpu_dag.pdf;

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,6 +32,17 @@ jobs:
       run: |
         tox
         coverage xml
+    - name: Run archspec commands
+      run: |
+        poetry install
+        poetry run archspec cpu
+        poetry run archspec cpu --dag
+    - name: Render output of archspec cpu --dag
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get install graphviz
+        poetry run archspec cpu --dag | dot -T pdf -o archspec_cpu_dag.pdf;
+        ls -l archspec_cpu_dag.pdf;
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v1
       with:

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -36,12 +36,12 @@ def dag():
             res += " (" + uarch.vendor + ")"
         return res
 
-    dag = Digraph()
+    cpu_uarch_dag = Digraph()
 
     for key in archspec.cpu.TARGETS:
         uarch = archspec.cpu.TARGETS[key]
-        dag.node(uarch.name, node_label(uarch))
+        cpu_uarch_dag.node(uarch.name, node_label(uarch))
         for parent in uarch.parents:
-            dag.edge(parent.name, uarch.name)
+            cpu_uarch_dag.edge(parent.name, uarch.name)
 
-    click.echo(dag.source)
+    click.echo(cpu_uarch_dag.source)

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -48,7 +48,7 @@ def cb_cpu_name(ctx, param, value):
 
 
 @main.command()
-@click.option('--name', is_flag=True, default=True, callback=cb_cpu_name)
-@click.option('--dag', is_flag=True, default=False, callback=cb_cpu_dag)
+@click.option("--name", is_flag=True, default=True, callback=cb_cpu_name)
+@click.option("--dag", is_flag=True, default=False, callback=cb_cpu_dag)
 def cpu():
     """archspec command line interface for CPU"""

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -19,14 +19,7 @@ def main():
     """archspec command line interface"""
 
 
-@main.command()
-def cpu():
-    """archspec command line interface for CPU"""
-    click.echo(archspec.cpu.host())
-
-
-@main.command()
-def dag():
+def print_cpu_dag(ctx, param, value):
     """Print Direct Acyclic Graph (DAG) for known CPU microarchitectures."""
 
     def node_label(uarch):
@@ -45,3 +38,17 @@ def dag():
             cpu_uarch_dag.edge(parent.name, uarch.name)
 
     click.echo(cpu_uarch_dag.source)
+    ctx.exit()
+
+
+def print_cpu_name(ctx, param, value):
+    """Print name of microarchitecture of host CPU."""
+    click.echo(archspec.cpu.host())
+    ctx.exit()
+
+
+@main.command()
+@click.option('--name', is_flag=True, default=True, callback=print_cpu_name)
+@click.option('--dag', is_flag=True, default=False, callback=print_cpu_dag)
+def cpu():
+    """archspec command line interface for CPU"""

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -19,7 +19,7 @@ def main():
     """archspec command line interface"""
 
 
-def print_cpu_dag(ctx, param, value):
+def print_cpu_dag(ctx, *args):
     """Print Direct Acyclic Graph (DAG) for known CPU microarchitectures."""
 
     def node_label(uarch):
@@ -41,7 +41,7 @@ def print_cpu_dag(ctx, param, value):
     ctx.exit()
 
 
-def print_cpu_name(ctx, param, value):
+def print_cpu_name(ctx, *args):
     """Print name of microarchitecture of host CPU."""
     click.echo(archspec.cpu.host())
     ctx.exit()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -19,7 +19,7 @@ def main():
     """archspec command line interface"""
 
 
-def print_cpu_dag(ctx, *args):
+def cb_cpu_dag(ctx, param, value):
     """Print Direct Acyclic Graph (DAG) for known CPU microarchitectures."""
 
     def node_label(uarch):
@@ -41,14 +41,14 @@ def print_cpu_dag(ctx, *args):
     ctx.exit()
 
 
-def print_cpu_name(ctx, *args):
+def cb_cpu_name(ctx, param, value):
     """Print name of microarchitecture of host CPU."""
     click.echo(archspec.cpu.host())
     ctx.exit()
 
 
 @main.command()
-@click.option('--name', is_flag=True, default=True, callback=print_cpu_name)
-@click.option('--dag', is_flag=True, default=False, callback=print_cpu_dag)
+@click.option('--name', is_flag=True, default=True, callback=cb_cpu_name)
+@click.option('--dag', is_flag=True, default=False, callback=cb_cpu_dag)
 def cpu():
     """archspec command line interface for CPU"""

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -26,8 +26,13 @@ def cpu():
 
 
 @main.command()
-@click.option("--cpu", 'only_cpu', is_flag=True, default=False,
-              help="Only print DAG for CPU microarchitectures")
+@click.option(
+    "--cpu",
+    "only_cpu",
+    is_flag=True,
+    default=False,
+    help="Only print DAG for CPU microarchitectures",
+)
 def graph(only_cpu):
     """Print Direct Acyclic Graph (DAG) for all known system aspects."""
 

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -44,7 +44,7 @@ def graph(only_cpu):
         return res
 
     # for now only CPU microarchitectures are supported so this looks a bit silly,
-    # but eventually the idea is to only print all aspects if no specific aspect was selected
+    # but eventually we want to print all aspects if no specific aspect was selected
     if not only_cpu:
         all_aspects = True
 

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -7,6 +7,7 @@ archspec command line interface
 """
 
 import click
+from graphviz import Digraph
 
 import archspec
 import archspec.cpu
@@ -22,3 +23,25 @@ def main():
 def cpu():
     """archspec command line interface for CPU"""
     click.echo(archspec.cpu.host())
+
+
+@main.command()
+def dag():
+    """Print Direct Acyclic Graph (DAG) for known CPU microarchitectures."""
+
+    def node_label(uarch):
+        """Create node label for specified Microarchitecture instance."""
+        res = uarch.name
+        if uarch.parents and uarch.vendor != uarch.parents[0].vendor:
+            res += " (" + uarch.vendor + ")"
+        return res
+
+    dag = Digraph()
+
+    for key in archspec.cpu.TARGETS:
+        uarch = archspec.cpu.TARGETS[key]
+        dag.node(uarch.name, node_label(uarch))
+        for parent in uarch.parents:
+            dag.edge(parent.name, uarch.name)
+
+    click.echo(dag.source)

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -26,8 +26,9 @@ def cpu():
 
 
 @main.command()
-@click.option("--cpu", is_flag=True, default=False, help="Only print DAG for CPU microarchitectures")
-def graph(cpu):
+@click.option("--cpu", 'only_cpu', is_flag=True, default=False,
+              help="Only print DAG for CPU microarchitectures")
+def graph(only_cpu):
     """Print Direct Acyclic Graph (DAG) for all known system aspects."""
 
     def node_label(uarch):
@@ -39,10 +40,10 @@ def graph(cpu):
 
     # for now only CPU microarchitectures are supported so this looks a bit silly,
     # but eventually the idea is to only print all aspects if no specific aspect was selected
-    if not cpu:
+    if not only_cpu:
         all_aspects = True
 
-    if cpu or all_aspects:
+    if only_cpu or all_aspects:
         cpu_uarch_dag = graphviz.Digraph()
 
         for uarch in archspec.cpu.TARGETS.values():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 python = ">=2.7 !=3.4.* !=3.3.* !=3.2.* !=3.1.* !=3.0.*"
 six = "^1.13.0"
 click = ">=7.1.2,<8.0"
+graphviz = ">=0.14,<1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def test_command_run_without_failure(cli_args):
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize("cli_args", [("cpu"), ("cpu --name")])
+@pytest.mark.parametrize("cli_args", [("cpu")])
 def test_cli_cpu_name(cli_args):
     runner = click.testing.CliRunner()
     result = runner.invoke(archspec.cli.main, cli_args)
@@ -26,9 +26,10 @@ def test_cli_cpu_name(cli_args):
     assert result.stdout.strip() in archspec.cpu.TARGETS
 
 
-def test_cli_cpu_dag():
+@pytest.mark.parametrize("cli_args", [("graph"), ("graph", "--cpu")])
+def test_cli_graph_dag(cli_args):
     runner = click.testing.CliRunner()
-    result = runner.invoke(archspec.cli.main, ("cpu", "--dag"))
+    result = runner.invoke(archspec.cli.main, cli_args)
     assert result.exit_code == 0
 
     assert result.stdout.startswith("digraph {")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,21 +41,25 @@ def test_cli_cpu_dag():
         #   power9 [label=power9]
         #   haswell [label=haswell]
         #   nocona [label="nocona (GenuineIntel)"]
-        assert re.search(r"^\s+" + uarch.name + r"\s+\[label=.+\]$", result.stdout, re.M)
+        assert re.search(
+            r"^\s+" + uarch.name + r"\s+\[label=.+\]$", result.stdout, re.M
+        )
         # every non-generic CPU microarchitecture has at least one parent
         # examples:
         #   haswell -> broadwell
         #   x86_64 -> nocona
         #   power7 -> power8
         if uarch.vendor != "generic":
-            assert re.search(r"^\s+[0-9a-z_]+\s+->\s+" + uarch.name + "$", result.stdout, re.M)
+            assert re.search(
+                r"^\s+[0-9a-z_]+\s+->\s+" + uarch.name + "$", result.stdout, re.M
+            )
 
     # hard check for a couple of patterns
     patterns = [
         "x86_64 [label=x86_64]",
         "power9 [label=power9]",
         "haswell [label=haswell]",
-        "nocona [label=\"nocona (GenuineIntel)\"]",
+        'nocona [label="nocona (GenuineIntel)"]',
         "x86_64 -> nocona",
         "power7 -> power8",
         "haswell -> broadwell",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,17 +2,70 @@
 # Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import pytest
 import click.testing
+import pytest
+import re
+
 import archspec
+import archspec.cpu
 import archspec.cli
 
 
-@pytest.mark.parametrize("cli_args", [("--help",), ("cpu", "--help"), ("cpu",)])
+@pytest.mark.parametrize("cli_args", [("--help",), ("cpu", "--help")])
 def test_command_run_without_failure(cli_args):
     runner = click.testing.CliRunner()
     result = runner.invoke(archspec.cli.main, cli_args)
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("cli_args", [("cpu"), ("cpu --name")])
+def test_cli_cpu_name(cli_args):
+    runner = click.testing.CliRunner()
+    result = runner.invoke(archspec.cli.main, cli_args)
+    assert result.exit_code == 0
+    assert result.stdout.strip() in archspec.cpu.TARGETS
+
+
+def test_cli_cpu_dag():
+    runner = click.testing.CliRunner()
+    result = runner.invoke(archspec.cli.main, ("cpu", "--dag"))
+    assert result.exit_code == 0
+
+    assert result.stdout.startswith("digraph {")
+
+    for key in archspec.cpu.TARGETS:
+        uarch = archspec.cpu.TARGETS[key]
+        # a label is set for every CPU microarchitecture
+        # examples:
+        #   x86_64 [label=x86_64]
+        #   power9 [label=power9]
+        #   haswell [label=haswell]
+        #   nocona [label="nocona (GenuineIntel)"]
+        assert re.search(r"^\s+" + uarch.name + r"\s+\[label=.+\]$", result.stdout, re.M)
+        # every non-generic CPU microarchitecture has at least one parent
+        # examples:
+        #   haswell -> broadwell
+        #   x86_64 -> nocona
+        #   power7 -> power8
+        if uarch.vendor != "generic":
+            assert re.search(r"^\s+[0-9a-z_]+\s+->\s+" + uarch.name + "$", result.stdout, re.M)
+
+    # hard check for a couple of patterns
+    patterns = [
+        "x86_64 [label=x86_64]",
+        "power9 [label=power9]",
+        "haswell [label=haswell]",
+        "nocona [label=\"nocona (GenuineIntel)\"]",
+        "x86_64 -> nocona",
+        "power7 -> power8",
+        "haswell -> broadwell",
+        "cascadelake -> icelake",
+        "cannonlake -> icelake",
+    ]
+    for pattern in patterns:
+        assert pattern in result.stdout
+
+    assert result.stdout.endswith("}\n")
 
 
 def test_cli_version():

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ commands =
 basepython = python3.7
 commands =
     poetry install -v
-    poetry run black --check -t py27 archspec --diff
-    poetry run black --check -t py27 tests --diff
+    poetry run black --check --diff -t py27 archspec
+    poetry run black --check --diff -t py27 tests

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ commands =
 basepython = python3.7
 commands =
     poetry install -v
-    poetry run black --check -t py27 archspec
-    poetry run black --check -t py27 tests
+    poetry run black --check -t py27 archspec --diff
+    poetry run black --check -t py27 tests --diff


### PR DESCRIPTION
Usage:

```bash
archspec graph | dot -T png -o cpu_dag.png
```

(`dot` command is provided by `graphviz`, see https://graphviz.org/)

I'm leveraging the [`graphviz`](https://pypi.org/project/graphviz) Python package, which makes this easy and clean...

TODO:

* [x] rename to `archspec graph`?
* [x] tests
* [ ] docs