### PR TITLE
Add a constraint on pyrsistent for Python 2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ sphinx_rtd_theme = [
   {version = "^0.4.3", python = "^3.5"}
 ]
 jsonschema = "^3.2.0"
+pyrsistent = [
+  {version="<0.17.0", python="^2.7"}
+]
 
 [tool.poetry.scripts]
 archspec = 'archspec.cli:main'


### PR DESCRIPTION
Extra safety to avoid Python 2.7 tests failure. See:

https://github.com/tobgu/pyrsistent/issues/205
https://github.com/tobgu/pyrsistent/issues/207
https://github.com/tobgu/pyrsistent/issues/208