### PR TITLE
Added detection for Graviton and Graviton2

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -191,7 +191,9 @@ def host():
 
     # Reverse sort of the depth for the inheritance tree among only targets we
     # can use. This gets the newest target we satisfy.
-    return sorted(candidates, key=lambda t: len(t.ancestors), reverse=True)[0]
+    return sorted(
+        candidates, key=lambda t: (len(t.ancestors), len(t.features)), reverse=True
+    )[0]
 
 
 def compatibility_check(architecture_family):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -39,6 +39,8 @@ from archspec.cpu import Microarchitecture
         "darwin-mojave-haswell",
         "darwin-mojave-skylake",
         "bgq-rhel6-power7",
+        "linux-amazon-graviton",
+        "linux-amazon-graviton2",
     ]
 )
 def expected_target(request, monkeypatch):


### PR DESCRIPTION
Added detection unit tests for both Graviton and Graviton2.

The detection heuristic for ARM has been extended to account for the number of features detected if the number of ancestors
is the same. This permits to disambiguate between Graviton and Graviton2.