### PR TITLE
Add tentative entry for Apple M1

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -99,7 +99,7 @@ def sysctl_info_dict():
     def sysctl(*args):
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
-    if platform.machine() == 'x86_64':
+    if platform.machine() == "x86_64":
         flags = (
             sysctl("-n", "machdep.cpu.features").lower()
             + " "
@@ -112,7 +112,9 @@ def sysctl_info_dict():
             "model name": sysctl("-n", "machdep.cpu.brand_string"),
         }
     else:
-        model = "m1" if "Apple" in sysctl("-n", 'machdep.cpu.brand_string') else 'unknown'
+        model = (
+            "m1" if "Apple" in sysctl("-n", "machdep.cpu.brand_string") else "unknown"
+        )
         info = {
             "vendor_id": "Apple",
             "flags": [],

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -99,17 +99,27 @@ def sysctl_info_dict():
     def sysctl(*args):
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
-    flags = (
-        sysctl("-n", "machdep.cpu.features").lower()
-        + " "
-        + sysctl("-n", "machdep.cpu.leaf7_features").lower()
-    )
-    info = {
-        "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
-        "flags": flags,
-        "model": sysctl("-n", "machdep.cpu.model"),
-        "model name": sysctl("-n", "machdep.cpu.brand_string"),
-    }
+    if platform.machine() == 'x86_64':
+        flags = (
+            sysctl("-n", "machdep.cpu.features").lower()
+            + " "
+            + sysctl("-n", "machdep.cpu.leaf7_features").lower()
+        )
+        info = {
+            "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
+            "flags": flags,
+            "model": sysctl("-n", "machdep.cpu.model"),
+            "model name": sysctl("-n", "machdep.cpu.brand_string"),
+        }
+    else:
+        model = "m1" if "Apple" in sysctl("-n", 'machdep.cpu.brand_string') else 'unknown'
+        info = {
+            "vendor_id": "Apple",
+            "flags": [],
+            "model": model,
+            "CPU implementer": "Apple",
+            "model name": sysctl("-n", "machdep.cpu.brand_string"),
+        }
     return info
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ pytest = [
   {version = ">=5.3.2", python = '^3.5'},
   {version = ">=3.5.2", python = '^2.7'}
 ]
+more_itertools = [
+  {version = ">=5.0.0", python = '^2.7'}
+]
 scandir = [
   {version = ">=1.10.0", python = '^2.7'}
 ]

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -39,6 +39,7 @@ from archspec.cpu import Microarchitecture
         "darwin-mojave-ivybridge",
         "darwin-mojave-haswell",
         "darwin-mojave-skylake",
+        "darwin-bigsur-m1",
         "bgq-rhel6-power7",
         "linux-amazon-graviton",
         "linux-amazon-graviton2",


### PR DESCRIPTION
fixes #38 

This PR permits to detect Apple M1. Logic at the moment is a bit rough (if it's not `x86_64` and it's Apple it's M1) but should suffice.