### PR TITLE
Detect the best generic level before the real microarchitecture

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -220,8 +220,6 @@ def host():
     candidates = [c for c in candidates if c > best_generic]
 
     # If we don't have candidates, return the best generic micro-architecture
-    # TODO: When dropping Python 2.X
-    # TODO: return max(candidates, key=sorting_fn, default=best_generic)
     if not candidates:
         return best_generic
 

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -212,7 +212,7 @@ def host():
 
     # Get the best generic micro-architecture
     generic_candidates = [c for c in candidates if c.vendor == "generic"]
-    best_generic = sorted(generic_candidates, key=sorting_fn, reverse=True)[0]
+    best_generic = max(generic_candidates, key=sorting_fn)
 
     # Filter the candidates to be descendant of the best generic candidate.
     # This is to avoid that the lack of a niche feature that can be disabled
@@ -220,12 +220,14 @@ def host():
     candidates = [c for c in candidates if c > best_generic]
 
     # If we don't have candidates, return the best generic micro-architecture
+    # TODO: When dropping Python 2.X
+    # TODO: return max(candidates, key=sorting_fn, default=best_generic)
     if not candidates:
         return best_generic
 
     # Reverse sort of the depth for the inheritance tree among only targets we
     # can use. This gets the newest target we satisfy.
-    return sorted(candidates, key=sorting_fn, reverse=True)[0]
+    return max(candidates, key=sorting_fn)
 
 
 def compatibility_check(architecture_family):

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -174,7 +174,7 @@ class Microarchitecture(object):
         return roots.pop()
 
     @property
-    def level(self):
+    def generic(self):
         """Returns the best generic architecture that is compatible with self"""
         generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
         return max(generics, key=lambda x: len(x.ancestors))

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -173,6 +173,12 @@ class Microarchitecture(object):
 
         return roots.pop()
 
+    @property
+    def level(self):
+        """Returns the best generic architecture that is compatible with self"""
+        generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
+        return max(generics, key=lambda x: len(x.ancestors))
+
     def to_dict(self, return_list_of_items=False):
         """Returns a dictionary representation of this object.
 

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -348,6 +348,6 @@ def test_all_alias_predicates_are_implemented():
         ("x86_64_v3", "x86_64_v3"),
     ],
 )
-def test_uarch_level(target, expected):
+def test_generic_property(target, expected):
     t = archspec.cpu.TARGETS[target]
     assert str(t.generic) == expected

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -350,4 +350,4 @@ def test_all_alias_predicates_are_implemented():
 )
 def test_uarch_level(target, expected):
     t = archspec.cpu.TARGETS[target]
-    assert str(t.level) == expected
+    assert str(t.generic) == expected

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -335,3 +335,19 @@ def test_all_alias_predicates_are_implemented():
     aliases_in_schema = set(fa_schema["patternProperties"]["([\\w]*)"]["properties"])
     aliases_implemented = set(archspec.cpu.alias._FEATURE_ALIAS_PREDICATE)
     assert aliases_implemented == aliases_in_schema
+
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("haswell", "x86_64_v3"),
+        ("bulldozer", "x86_64_v2"),
+        ("zen2", "x86_64_v3"),
+        ("icelake", "x86_64_v4"),
+        # Check that a generic level returns itself
+        ("x86_64_v3", "x86_64_v3"),
+    ],
+)
+def test_uarch_level(target, expected):
+    t = archspec.cpu.TARGETS[target]
+    assert str(t.level) == expected

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -26,6 +26,7 @@ from archspec.cpu import Microarchitecture
         "linux-rhel7-skylake_avx512",
         "linux-rhel7-ivybridge",
         "linux-rhel7-haswell",
+        "linux-rhel7-x86_64_v3",
         "linux-rhel7-zen",
         "linux-ubuntu20.04-zen3",
         "linux-scientific7-k10",


### PR DESCRIPTION
fixes #40 

The detection algorithm is changed to detect first the best generic level for the current architecture, and then try to detect the real microarchitecture. Candidates for the real microarchitecture must support all the features of the best generic architecture. If no real microarchitecture is detected, then the best generic is returned.