### PR TITLE
Detection code for generic riscv and u74mc uarch.

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -300,3 +300,19 @@ def compatibility_check_for_aarch64(info, target):
         and (target.vendor == vendor or target.vendor == "generic")
         and target.features.issubset(features)
     )
+
+
+@compatibility_check(architecture_family="riscv64")
+def compatibility_check_for_riscv64(info, target):
+    """Compatibility check for riscv64 architectures."""
+    basename = "riscv64"
+    uarch = info.get("uarch", "generic")
+
+    # sifive unmatched board
+    if uarch == "sifive,u74-mc":
+        uarch = "u74mc"
+
+    arch_root = TARGETS[basename]
+    return (target == arch_root or arch_root in target.ancestors) and (
+        target == uarch or target.vendor == "generic"
+    )

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -306,11 +306,14 @@ def compatibility_check_for_aarch64(info, target):
 def compatibility_check_for_riscv64(info, target):
     """Compatibility check for riscv64 architectures."""
     basename = "riscv64"
-    uarch = info.get("uarch", "generic")
+    uarch = info.get("uarch")
 
     # sifive unmatched board
     if uarch == "sifive,u74-mc":
         uarch = "u74mc"
+    # catch-all for unknown uarchs
+    else:
+        uarch = "riscv64"
 
     arch_root = TARGETS[basename]
     return (target == arch_root or arch_root in target.ancestors) and (

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -44,6 +44,7 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "bgq-rhel6-power7",
         "linux-amazon-graviton",
         "linux-amazon-graviton2",
+        "linux-sifive-u74mc",
     ]
 )
 def expected_target(request, monkeypatch):


### PR DESCRIPTION
Add function to detect processors of the riscv64 family.
Two riscv64 uarchs are supported, generic and u74mc.

This PR is dependent on https://github.com/archspec/archspec-json/pull/35 and will require the archspec-json submodule to be moved forward.

This commit passes all tox tests (which were run on riscv). It also properly detects the u74mc uarch when run on the SiFive Unmatched board.

