### PR TITLE
Update how we write dependencies to speed-up poetry

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -80,9 +80,9 @@ def proc_cpuinfo():
 
 
 def _check_output(args, env):
-    output = subprocess.Popen(args, stdout=subprocess.PIPE, env=env).communicate()[
-        0
-    ]  # pylint: disable=consider-using-with
+    output = subprocess.Popen(  # pylint: disable=consider-using-with
+        args, stdout=subprocess.PIPE, env=env
+    ).communicate()[0]
     return six.text_type(output.decode("utf-8"))
 
 

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -61,7 +61,7 @@ def proc_cpuinfo():
     ``/proc/cpuinfo``
     """
     info = {}
-    with open("/proc/cpuinfo") as file:
+    with open("/proc/cpuinfo") as file:  # pylint: disable=unspecified-encoding
         for line in file:
             key, separator, value = line.partition(":")
 
@@ -80,7 +80,9 @@ def proc_cpuinfo():
 
 
 def _check_output(args, env):
-    output = subprocess.Popen(args, stdout=subprocess.PIPE, env=env).communicate()[0]
+    output = subprocess.Popen(args, stdout=subprocess.PIPE, env=env).communicate()[
+        0
+    ]  # pylint: disable=consider-using-with
     return six.text_type(output.decode("utf-8"))
 
 
@@ -283,7 +285,7 @@ def compatibility_check_for_x86_64(info, target):
     arch_root = TARGETS[basename]
     return (
         (target == arch_root or arch_root in target.ancestors)
-        and (target.vendor == vendor or target.vendor == "generic")
+        and target.vendor in (vendor, "generic")
         and target.features.issubset(features)
     )
 
@@ -298,7 +300,7 @@ def compatibility_check_for_aarch64(info, target):
     arch_root = TARGETS[basename]
     return (
         (target == arch_root or arch_root in target.ancestors)
-        and (target.vendor == vendor or target.vendor == "generic")
+        and target.vendor in (vendor, "generic")
         and target.features.issubset(features)
     )
 

--- a/archspec/cpu/schema.py
+++ b/archspec/cpu/schema.py
@@ -11,7 +11,7 @@ import os.path
 try:
     from collections.abc import MutableMapping  # novm
 except ImportError:
-    from collections import MutableMapping
+    from collections import MutableMapping  # pylint: disable=deprecated-class
 
 
 class LazyDictionary(MutableMapping):
@@ -56,7 +56,7 @@ def _load_json_file(json_file):
 
     def _factory():
         filename = os.path.join(json_dir, json_file)
-        with open(filename, "r") as file:
+        with open(filename, "r") as file:  # pylint: disable=unspecified-encoding
             return json.load(file)
 
     return _factory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,46 +25,47 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=2.7 !=3.4.* !=3.3.* !=3.2.* !=3.1.* !=3.0.* <4"
+python = "==2.7 || ^3.5"
 six = "^1.13.0"
-click = ">=7.1.2,<8.0"
+click = "^7"
 
 [tool.poetry.dev-dependencies]
 pytest = [
-  {version = ">=5.3.2", python = '^3.5'},
-  {version = ">=3.5.2", python = '^2.7'}
+  {version = "^6", python = '^3.6'},
+  {version = "~5", python = '==3.5'},
+  {version = "~3", python = '==2.7'}
 ]
 more_itertools = [
-  {version = ">=5.0.0", python = '^2.7'}
+  {version = "~5", python = '==2.7'}
 ]
 scandir = [
-  {version = ">=1.10.0", python = '^2.7'}
+  {version = "~1", python = '==2.7'}
 ]
 pytest-cov = "^2.8.1"
 coverage = "^5.3"
 pylint = [
-  {version = "^2.4.4", python = "^3.5"}
+  {version = "^2", python = "==3.9"}
 ]
 flake8 = [
-  {version = "^3.7.9", python = "^3.5"}
+  {version = "^4", python = "==3.9"}
 ]
 black = [
-  {version = ">19.10b0", python = "^3.6"}
+  {version = "==21.12b0", python = "==3.9"}
 ]
 sphinx = [
-  {version = "^2.3.1", python = "^3.5"}
+  {version = "^4", python = "^3.6"}
 ]
 sphinx_rtd_theme = [
-  {version = "^0.4.3", python = "^3.5"}
+  {version = "^1", python = "^3.6"}
 ]
 jsonschema = "^3.2.0"
 pyrsistent = [
-  {version="<0.17.0", python="^2.7"}
+  {version="~0.16", python="==2.7"}
 ]
 
 [tool.poetry.scripts]
 archspec = 'archspec.cli:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ flake8 = [
   {version = "^4", python = "^3.6"}
 ]
 black = [
-  {version = "==21.12b0", python = "^3.6"}
+  {version = "==21.12b0", python = "^3.8"}
 ]
 sphinx = [
   {version = "^4", python = "^3.6"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,13 @@ scandir = [
 pytest-cov = "^2.8.1"
 coverage = "^5.3"
 pylint = [
-  {version = "^2", python = "==3.9"}
+  {version = "^2", python = "^3.6"}
 ]
 flake8 = [
-  {version = "^4", python = "==3.9"}
+  {version = "^4", python = "^3.6"}
 ]
 black = [
-  {version = "==21.12b0", python = "==3.9"}
+  {version = "==21.12b0", python = "^3.6"}
 ]
 sphinx = [
   {version = "^4", python = "^3.6"}

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 basepython = python3.9
 commands =
     poetry install -v
-    poetry run pylint archspec
+    poetry run pylint --py-version=2.7 archspec
 
 [testenv:flake8]
 basepython = python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist = py27, py35, py36, py37, py38, py39, pylint, flake8, black
 
 [gh-actions]
 python =
-    3.9: py39
-    3.8: py38, black, pylint, flake8
+    3.9: py39, black, pylint, flake8
+    3.8: py38
     3.7: py37
     3.6: py36
     3.5: py35
@@ -18,19 +18,19 @@ commands =
     poetry run pytest --cov=archspec
 
 [testenv:pylint]
-basepython = python3.8
+basepython = python3.9
 commands =
     poetry install -v
     poetry run pylint archspec
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3.9
 commands =
     poetry install -v
     poetry run flake8 --max-line-length=88 archspec
 
 [testenv:black]
-basepython = python3.8
+basepython = python3.9
 commands =
     poetry install -v
     poetry run black --check -t py27 archspec


### PR DESCRIPTION
CI has been failing for the last 3 weeks due to poetry not being able to resolve dependencies in a reasonable amount of time / failing while doing that. There are many open issues about that, for instance:
- https://github.com/python-poetry/poetry/issues/2094

Reading these [FAQs](https://python-poetry.org/docs/faq/#why-is-the-dependency-resolution-process-slow) it seems poetry doesn't cope well with open ranges, so this PR tries to mitigate the issue by giving upper bounds to dependencies. 

It also fixes a few style issues reported by latest version of `pylint`.