### PR TITLE
Update dependency version (click)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,11 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "==2.7 || ^3.5"
 six = "^1.13.0"
-click = "^7"
+click = [
+  {version = "^8", python = '^3.6'},
+  {version = "^7", python = '==3.5'},
+  {version = "^7", python = '==2.7'}
+]
 
 [tool.poetry.dev-dependencies]
 pytest = [


### PR DESCRIPTION
fixes #68 

Click:
- ^7 for Python 3.5 and 2.7
- ^8 for Python ^3.6