### PR TITLE
Detect Apple M1 running in Rosetta 2 emulator mode

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -102,17 +102,29 @@ def sysctl_info_dict():
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
     if platform.machine() == "x86_64":
-        flags = (
-            sysctl("-n", "machdep.cpu.features").lower()
-            + " "
-            + sysctl("-n", "machdep.cpu.leaf7_features").lower()
-        )
-        info = {
-            "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
-            "flags": flags,
-            "model": sysctl("-n", "machdep.cpu.model"),
-            "model name": sysctl("-n", "machdep.cpu.brand_string"),
-        }
+        # Rosetta 2 emulator
+        if "Apple" in sysctl("-n", "machdep.cpu.brand_string"):
+            flags = (
+                sysctl("-n", "machdep.cpu.features").lower()
+            )
+            info = {
+                "vendor_id": "Apple",
+                "flags": flags,
+                "model": "m1",
+                "model name": sysctl("-n", "machdep.cpu.brand_string"),
+            }
+        else:
+            flags = (
+                sysctl("-n", "machdep.cpu.features").lower()
+                + " "
+                + sysctl("-n", "machdep.cpu.leaf7_features").lower()
+            )
+            info = {
+                "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
+                "flags": flags,
+                "model": sysctl("-n", "machdep.cpu.model"),
+                "model name": sysctl("-n", "machdep.cpu.brand_string"),
+            }
     else:
         model = (
             "m1" if "Apple" in sysctl("-n", "machdep.cpu.brand_string") else "unknown"


### PR DESCRIPTION
Fixes https://github.com/archspec/archspec/issues/76.

@alalazo brought up the idea to be more specific than just testing for `Apple` and then conclude that it is an M1 processor.

One could test for `Apple M1` in `string` or `apple m1` in `string.lower()`.

I've used this code with success in spack.