### PR TITLE
speed up microarchitecture compare

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -106,7 +106,7 @@ class Microarchitecture(object):
             self.name == other.name
             and self.vendor == other.vendor
             and self.features == other.features
-            and self.ancestors == other.ancestors
+            and self.parents == other.parents
             and self.compilers == other.compilers
             and self.generation == other.generation
         )

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -106,7 +106,7 @@ class Microarchitecture(object):
             self.name == other.name
             and self.vendor == other.vendor
             and self.features == other.features
-            and self.parents == other.parents
+            and self.parents == other.parents  # avoid ancestors here
             and self.compilers == other.compilers
             and self.generation == other.generation
         )


### PR DESCRIPTION
The original constructed a new ancestor list for every comparison, then
compared each microarchitecture in it by *creating another ancestor
list* and so forth, recursively creating a surprisingly large number of
throw-away lists.  Doing an equality comparison on the static `parents`
list has the same effect without generating all the new throw-away
lists.

For a recent database created by @vsoch this change takes end-to-end time of `spack find` on an m1 mac from 18 seconds to 13 seconds with hot cache.  Just under a 30% drop.