### PR TITLE
Fix typos and markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-[![](https://github.com/archspec/archspec/workflows/Unit%20tests/badge.svg)](https://github.com/archspec/archspec/actions)
-[![codecov](https://codecov.io/gh/archspec/archspec/branch/master/graph/badge.svg)](https://codecov.io/gh/archspec/archspec)
-[![Documentation Status](https://readthedocs.org/projects/archspec/badge/?version=latest)](https://archspec.readthedocs.io/en/latest/?badge=latest)
-
-
 # Archspec (Python bindings)
+
+[![CI](https://github.com/archspec/archspec/workflows/Unit%20tests/badge.svg)](https://github.com/archspec/archspec/actions)
+[![CodeCov](https://codecov.io/gh/archspec/archspec/branch/master/graph/badge.svg)](https://codecov.io/gh/archspec/archspec)
+[![Documentation Status](https://readthedocs.org/projects/archspec/badge/?version=latest)](https://archspec.readthedocs.io/en/latest/?badge=latest)
 
 Archspec aims at providing a standard set of human-understandable labels for
 various aspects of a system architecture  like CPU, network fabrics, etc. and
@@ -18,23 +17,30 @@ compatibility relationships among different CPU microarchitectures.
 The `archspec` Python package needs [poetry](https://python-poetry.org/) to
 be installed from VCS sources. The preferred method to install it is via
 its custom installer outside of any virtual environment:
+
 ```console
-$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ```
+
 You can refer to [Poetry's documentation](https://python-poetry.org/docs/#installation)
 for further details or for other methods to install this tool. You'll also need `tox`
 to run unit test:
+
 ```console
-$ pip install --user tox
+pip install --user tox
 ```
+
 Finally you'll need to clone the repository:
+
 ```console
-$ git clone --recursive https://github.com/archspec/archspec.git
+git clone --recursive https://github.com/archspec/archspec.git
 ```
 
 ### Running unit tests
+
 Once you have your environment ready you can run `archspec` unit tests
 using ``tox`` from the root of the repository:
+
 ```console
 $ tox
   [ ... ]
@@ -54,7 +60,7 @@ $ tox
 If you are referencing `archspec` in a publication, please cite the following
 paper:
 
- * Massimiliano Culpo, Gregory Becker, Carlos Eduardo Arango Gutierrez, Kenneth
+* Massimiliano Culpo, Gregory Becker, Carlos Eduardo Arango Gutierrez, Kenneth
    Hoste, and Todd Gamblin.
    [**`archspec`: A library for detecting, labeling, and reasoning about
    microarchitectures**](https://tgamblin.github.io/pubs/archspec-canopie-hpc-2020.pdf).

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -156,7 +156,7 @@ def test_equality(supported_target):
         ("cascadelake >= cannonlake", False),
         ("cascadelake == cannonlake", False),
         ("cascadelake != cannonlake", True),
-        # Test ordering wih x86_64 virtual versions
+        # Test ordering with x86_64 virtual versions
         ("x86_64 < x86_64_v2", True),
         ("x86_64_v4 < x86_64_v2", False),
         ("core2 > x86_64_v2", False),


### PR DESCRIPTION
Found via these commands:

    codespell . -L complies
    markdownlint *.md --disable MD013

See a detailed description of the rules is available at
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md