### PR TITLE
Rename Graviton products with ARM uarch names

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -322,6 +322,11 @@ def compatibility_check_for_aarch64(info, target):
     features = set(info.get("Features", "").split())
     vendor = info.get("CPU implementer", "generic")
 
+    # FIXME: At the moment it's not clear how to detect compatibility with
+    # FIXME: a specific version of the architecture
+    if target.vendor == "generic" and target.name != "aarch64":
+        return False
+
     arch_root = TARGETS[basename]
     return (
         (target == arch_root or arch_root in target.ancestors)

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -43,9 +43,9 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "darwin-bigsur-m1",
         "darwin-monterey-m1",
         "bgq-rhel6-power7",
-        "linux-amazon-graviton",
-        "linux-amazon-graviton2",
-        "linux-amazon-graviton3",
+        "linux-amazon-cortex_a72",
+        "linux-amazon-neoverse_n1",
+        "linux-amazon-neoverse_v1",
         "linux-sifive-u74mc",
         "linux-asahi-m1",
     ]


### PR DESCRIPTION
This PR changes the name of a few microarchitectures of the `AArch64` family, and introduces generic targets.

Modifications:
- [x] Incorporate https://github.com/archspec/archspec-json/pull/57 
- [x] Fix detection tests