### PR TITLE
Drop Python 2.7 and Python 3.5 official support

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies (Common)
       run: |
         pip install poetry tox-gh-actions coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,6 +17,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3

--- a/archspec/__init__.py
+++ b/archspec/__init__.py
@@ -1,2 +1,2 @@
 """Init file to avoid namespace packages"""
-__version__ = "0.1.4"
+__version__ = "0.2.0"

--- a/archspec/cpu/alias.py
+++ b/archspec/cpu/alias.py
@@ -3,13 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Aliases for microarchitecture features."""
-# pylint: disable=useless-object-inheritance
 from .schema import TARGETS_JSON, LazyDictionary
 
 _FEATURE_ALIAS_PREDICATE = {}
 
 
-class FeatureAliasTest(object):
+class FeatureAliasTest:
     """A test that must be passed for a feature alias to succeed.
 
     Args:
@@ -48,7 +47,7 @@ def alias_predicate(func):
 
     # Check we didn't register anything else with the same name
     if name in _FEATURE_ALIAS_PREDICATE:
-        msg = 'the alias predicate "{0}" already exists'.format(name)
+        msg = f'the alias predicate "{name}" already exists'
         raise KeyError(msg)
 
     _FEATURE_ALIAS_PREDICATE[name] = func

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -11,8 +11,6 @@ import re
 import subprocess
 import warnings
 
-import six
-
 from .microarchitecture import generic_microarchitecture, TARGETS
 from .schema import TARGETS_JSON
 
@@ -80,10 +78,9 @@ def proc_cpuinfo():
 
 
 def _check_output(args, env):
-    output = subprocess.Popen(  # pylint: disable=consider-using-with
-        args, stdout=subprocess.PIPE, env=env
-    ).communicate()[0]
-    return six.text_type(output.decode("utf-8"))
+    with subprocess.Popen(args, stdout=subprocess.PIPE, env=env) as proc:
+        output = proc.communicate()[0]
+    return str(output.decode("utf-8"))
 
 
 def _machine():
@@ -273,7 +270,7 @@ def compatibility_check(architecture_family):
             this test can be used, e.g. x86_64 or ppc64le etc.
     """
     # Turn the argument into something iterable
-    if isinstance(architecture_family, six.string_types):
+    if isinstance(architecture_family, str):
         architecture_family = (architecture_family,)
 
     def decorator(func):

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -5,13 +5,10 @@
 """Types and functions to manage information
 on CPU microarchitectures.
 """
-# pylint: disable=useless-object-inheritance
 import functools
 import platform
 import re
 import warnings
-
-import six
 
 import archspec
 import archspec.cpu.alias
@@ -27,7 +24,7 @@ def coerce_target_names(func):
 
     @functools.wraps(func)
     def _impl(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             if other not in TARGETS:
                 msg = '"{0}" is not a valid target name'
                 raise ValueError(msg.format(other))
@@ -38,7 +35,7 @@ def coerce_target_names(func):
     return _impl
 
 
-class Microarchitecture(object):
+class Microarchitecture:
     """Represents a specific CPU micro-architecture.
 
     Args:
@@ -150,7 +147,7 @@ class Microarchitecture(object):
 
     def __contains__(self, feature):
         # Feature must be of a string type, so be defensive about that
-        if not isinstance(feature, six.string_types):
+        if not isinstance(feature, str):
             msg = "only objects of string types are accepted [got {0}]"
             raise TypeError(msg.format(str(type(feature))))
 
@@ -168,7 +165,7 @@ class Microarchitecture(object):
         """Returns the architecture family a given target belongs to"""
         roots = [x for x in [self] + self.ancestors if not x.ancestors]
         msg = "a target is expected to belong to just one architecture family"
-        msg += "[found {0}]".format(", ".join(str(x) for x in roots))
+        msg += f"[found {', '.join(str(x) for x in roots)}]"
         assert len(roots) == 1, msg
 
         return roots.pop()
@@ -318,9 +315,6 @@ def _known_microarchitectures():
     """Returns a dictionary of the known micro-architectures. If the
     current host platform is unknown adds it too as a generic target.
     """
-    # pylint: disable=fixme
-    # TODO: Simplify this logic using object_pairs_hook to OrderedDict
-    # TODO: when we stop supporting python2.6
 
     def fill_target_from_dict(name, data, targets):
         """Recursively fills targets by adding the micro-architecture

--- a/archspec/cpu/schema.py
+++ b/archspec/cpu/schema.py
@@ -5,16 +5,12 @@
 """Global objects with the content of the microarchitecture
 JSON file and its schema
 """
+import collections.abc
 import json
 import os.path
 
-try:
-    from collections.abc import MutableMapping  # novm
-except ImportError:
-    from collections import MutableMapping  # pylint: disable=deprecated-class
 
-
-class LazyDictionary(MutableMapping):
+class LazyDictionary(collections.abc.MutableMapping):
     """Lazy dictionary that gets constructed on first access to any object key
 
     Args:
@@ -56,7 +52,7 @@ def _load_json_file(json_file):
 
     def _factory():
         filename = os.path.join(json_dir, json_file)
-        with open(filename, "r") as file:  # pylint: disable=unspecified-encoding
+        with open(filename, "r", encoding="utf-8") as file:
             return json.load(file)
 
     return _factory

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Archspec's Contributors"
 author = "Archspec's Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.4'
+release = '0.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,75 +1,46 @@
 [tool.poetry]
 name = "archspec"
-version = "0.1.4"
+version = "0.2.0"
 description = "A library to query system architecture"
 license = "Apache-2.0 OR MIT"
 authors = ["archspec developers <maintainers@spack.io>"]
 maintainers = [
-"Greg Becker <maintainers@spack.io>",
-"Massimiliano Culpo <massimiliano.culpo@gmail.com>",
-"Todd Gamblin <maintainers@spack.io>",
-"Kenneth Hoste <kenneth.hoste@ugent.be>"
+    "Greg Becker <maintainers@spack.io>",
+    "Massimiliano Culpo <massimiliano.culpo@gmail.com>",
+    "Todd Gamblin <maintainers@spack.io>",
+    "Kenneth Hoste <kenneth.hoste@ugent.be>"
 ]
 repository = "https://github.com/archspec/archspec.git"
 homepage = "https://github.com/archspec/archspec"
 documentation = "https://archspec.readthedocs.io"
 readme = "README.md"
 classifiers = [
-"Development Status :: 3 - Alpha",
-"Intended Audience :: Developers",
-"Intended Audience :: Information Technology",
-"Intended Audience :: Science/Research",
-"Operating System :: MacOS",
-"Operating System :: POSIX :: Linux",
-"Operating System :: Unix"
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Unix"
 ]
 
 [tool.poetry.dependencies]
-python = "==2.7 || ^3.5"
-six = "^1.13.0"
-click = [
-  {version = "^8", python = '^3.6'},
-  {version = "^7", python = '==3.5'},
-  {version = "^7", python = '==2.7'}
-]
+python = "^3.7"
+click = "^8"
 
 [tool.poetry.dev-dependencies]
-pytest = [
-  {version = "^6", python = '^3.6'},
-  {version = "~5", python = '==3.5'},
-  {version = "~3", python = '==2.7'}
-]
-more_itertools = [
-  {version = "~5", python = '==2.7'}
-]
-scandir = [
-  {version = "~1", python = '==2.7'}
-]
-pytest-cov = "^2.8.1"
-coverage = "^5.3"
-pylint = [
-  {version = "^2", python = "^3.7"}
-]
-flake8 = [
-  {version = "^4", python = "^3.7"}
-]
+pytest = "^7"
+pytest-cov = "^4"
+jsonschema = "^4"
+pylint = "^2"
+flake8 = "^5"
 black = [
-  {version = "==21.12b0", python = "^3.8"}
-]
-sphinx = [
-  {version = "^4", python = "^3.7"}
-]
-sphinx_rtd_theme = [
-  {version = "^1", python = "^3.7"}
-]
-jsonschema = "^3.2.0"
-pyrsistent = [
-  {version="~0.16", python="==2.7"}
+    { version = "^22.0.0", python = "^3.8" }
 ]
 
 [tool.poetry.scripts]
 archspec = 'archspec.cli:main'
 
 [build-system]
-requires = ["poetry>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,18 +25,17 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "3.6.15 || ^3.7"
 click = "^8"
 
 [tool.poetry.dev-dependencies]
-pytest = "^7"
-pytest-cov = "^4"
-jsonschema = "^4"
-pylint = "^2"
-flake8 = "^5"
-black = [
-    { version = "^22.0.0", python = "^3.8" }
-]
+pytest = { version = "^7", python = "^3.7" }
+pytest-cov = { version = "^4", python = "^3.7" }
+jsonschema = { version = "^4", python = "^3.7" }
+pylint = { version = "^2", python = "^3.7" }
+flake8 = { version = "^5", python = "^3.7" }
+black = { version = "^22.0.0", python = "^3.8" }
+
 
 [tool.poetry.scripts]
 archspec = 'archspec.cli:main'

--- a/tests/test_archspec.py
+++ b/tests/test_archspec.py
@@ -6,6 +6,6 @@ import archspec
 
 
 def test_version():
-    assert archspec.__version__ == "0.1.4"
+    assert archspec.__version__ == "0.2.0"
     with open("pyproject.toml") as fp:
         assert 'version = "' + archspec.__version__ + '"\n' in fp.read()

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
 isolated_build = true
-envlist = py27, py35, py36, py37, py38, py39, py310, pylint, flake8, black
+envlist = py36, py37, py38, py39, py310, py311, pylint, flake8, black
 
 [gh-actions]
 python =
-    3.10: py310
-    3.9: py39, black, pylint, flake8
+    3.11: py311
+    3.10: py310, black, pylint, flake8
+    3.9: py39
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
-    2.7: py27
 
 [testenv]
 whitelist_externals = poetry
@@ -19,20 +18,20 @@ commands =
     poetry run pytest --cov=archspec
 
 [testenv:pylint]
-basepython = python3.9
+basepython = python3.10
 commands =
-    poetry install -v
-    poetry run pylint --py-version=2.7 archspec
+    poetry install -v --with=linters
+    poetry run pylint --py-version=3.6 archspec
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.10
 commands =
-    poetry install -v
+    poetry install -v --with=linters
     poetry run flake8 --max-line-length=88 archspec
 
 [testenv:black]
-basepython = python3.9
+basepython = python3.10
 commands =
-    poetry install -v
-    poetry run black --check -t py27 archspec
-    poetry run black --check -t py27 tests
+    poetry install -v --with=linters
+    poetry run black --check -t py36 archspec
+    poetry run black --check -t py36 tests

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,11 @@ commands =
     poetry install -v
     poetry run pytest --cov=archspec
 
+[testenv:py36]
+commands =
+    pip install pytest pytest-cov jsonschema
+    pytest --cov=archspec
+
 [testenv:pylint]
 basepython = python3.10
 commands =


### PR DESCRIPTION
Modifications:
- [x] Remove support for Python 2.7 and Python 3.5
- [x] Add support for Python 3.11
- [x] Remove dependency on `six`