### PR TITLE
Rewrite `archspec` CLI with `argparse` instead of `click`

### DIFF
--- a/archspec/__main__.py
+++ b/archspec/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from .cli import main
+
+sys.exit(main())

--- a/archspec/__main__.py
+++ b/archspec/__main__.py
@@ -1,3 +1,7 @@
+"""
+Run the `archspec` CLI as a module.
+"""
+
 import sys
 from .cli import main
 

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -9,8 +9,6 @@ archspec command line interface
 import argparse
 import typing
 
-import click
-
 import archspec
 import archspec.cpu
 
@@ -20,7 +18,6 @@ def _make_parser() -> argparse.ArgumentParser:
         "archspec",
         description="archspec command line interface",
         add_help=False,
-        exit_on_error=False,
     )
     parser.add_argument(
         "--version",
@@ -44,6 +41,7 @@ def _make_parser() -> argparse.ArgumentParser:
 
     cpu_command = subcommands.add_parser(
         "cpu",
+        help="archspec command line interface for CPU",
         description="archspec command line interface for CPU",
     )
     cpu_command.set_defaults(run=cpu)

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -15,15 +15,6 @@ import archspec
 import archspec.cpu
 
 
-class ErrorCatchingArgumentParser(argparse.ArgumentParser):
-    """An `ArgumentParser` that doesn't exit by itself.
-    """
-
-    def exit(self, status=0, message=None):
-        if status:
-            raise argparse.ArgumentError(None, message)
-
-
 def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         "archspec",

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -24,14 +24,9 @@ def _make_parser() -> argparse.ArgumentParser:
         "-V",
         help="Show the version and exit.",
         action="version",
-        version="archspec, version {}".format(archspec.__version__),
+        version=f"archspec, version {archspec.__version__}",
     )
-    parser.add_argument(
-        "--help",
-        "-h",
-        help="Show the help and exit.",
-        action="help"
-    )
+    parser.add_argument("--help", "-h", help="Show the help and exit.", action="help")
 
     subcommands = parser.add_subparsers(
         title="command",
@@ -49,12 +44,14 @@ def _make_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def cpu(args: argparse.Namespace) -> int:
+def cpu() -> int:
+    """Run the `archspec cpu` subcommand."""
     print(archspec.cpu.host())
     return 0
 
 
 def main(argv: typing.Optional[typing.List[str]] = None) -> int:
+    """Run the `archspec` command line interface."""
     parser = _make_parser()
 
     try:
@@ -66,5 +63,4 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
         parser.print_help()
         return 0
 
-    return args.run(args)
-
+    return args.run()

--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -6,19 +6,76 @@
 archspec command line interface
 """
 
+import argparse
+import typing
+
 import click
 
 import archspec
 import archspec.cpu
 
 
-@click.group(name="archspec")
-@click.version_option(version=archspec.__version__)
-def main():
-    """archspec command line interface"""
+class ErrorCatchingArgumentParser(argparse.ArgumentParser):
+    """An `ArgumentParser` that doesn't exit by itself.
+    """
+
+    def exit(self, status=0, message=None):
+        if status:
+            raise argparse.ArgumentError(None, message)
 
 
-@main.command()
-def cpu():
-    """archspec command line interface for CPU"""
-    click.echo(archspec.cpu.host())
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        "archspec",
+        description="archspec command line interface",
+        add_help=False,
+        exit_on_error=False,
+    )
+    parser.add_argument(
+        "--version",
+        "-V",
+        help="Show the version and exit.",
+        action="version",
+        version="archspec, version {}".format(archspec.__version__),
+    )
+    parser.add_argument(
+        "--help",
+        "-h",
+        help="Show the help and exit.",
+        action="help"
+    )
+
+    subcommands = parser.add_subparsers(
+        title="command",
+        metavar="COMMAND",
+        dest="command",
+    )
+
+    cpu_command = subcommands.add_parser(
+        "cpu",
+        description="archspec command line interface for CPU",
+    )
+    cpu_command.set_defaults(run=cpu)
+
+    return parser
+
+
+def cpu(args: argparse.Namespace) -> int:
+    print(archspec.cpu.host())
+    return 0
+
+
+def main(argv: typing.Optional[typing.List[str]] = None) -> int:
+    parser = _make_parser()
+
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as err:
+        return err.code
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    return args.run(args)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "3.6.15 || ^3.7"
-click = "^8"
 
 [tool.poetry.dev-dependencies]
 pytest = { version = "^7", python = "^3.7" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,21 +2,22 @@
 # Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import io
+from unittest import mock
+
 import pytest
-import click.testing
 import archspec
 import archspec.cli
 
 
 @pytest.mark.parametrize("cli_args", [("--help",), ("cpu", "--help"), ("cpu",)])
 def test_command_run_without_failure(cli_args):
-    runner = click.testing.CliRunner()
-    result = runner.invoke(archspec.cli.main, cli_args)
-    assert result.exit_code == 0
+    result = archspec.cli.main(cli_args)
+    assert result == 0
 
 
 def test_cli_version():
-    runner = click.testing.CliRunner()
-    result = runner.invoke(archspec.cli.main, ("--version"))
-    assert result.exit_code == 0
-    assert result.stdout == "archspec, version " + archspec.__version__ + "\n"
+    with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+        result = archspec.cli.main(["--version"])
+    assert result == 0
+    assert stdout.getvalue() == "archspec, version " + archspec.__version__ + "\n"


### PR DESCRIPTION
As discussed in #108, this PR removes the `click` dependency for the CLI by using the built-in `argparse` module instead.

I also added a `__main__.py` file so that the `archspec` CLI can be invoked as a module as well, with `python -m archspec`; I think this is quite standard for modules that also install an executable.