### PR TITLE
Provide host output for Windows

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -133,8 +133,8 @@ def wmic_cpuinfo():
             try:
                 idx = parts.index(inner_tag)
                 info[swap] = parts[idx + 1]
-            except:
-                continue
+            except (ValueError, IndexError):
+                pass
 
     swaps = [
         ('ProcessorType', 'processor'),

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -98,7 +98,8 @@ def _machine():
         #
         # See: https://bugs.python.org/issue42704
         output = _check_output(
-            ["sysctl", "-n", "machdep.cpu.brand_string"], env=_ensure_bin_usrbin_in_path()
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            env=_ensure_bin_usrbin_in_path()
         ).strip()
 
         if "Apple" in output:


### PR DESCRIPTION
Implements `archspec.cpu.host()` for Windows. This tries to match the output obtained when running in WSL since they run on the same architecture.

Related issue: #113 

Current output on my machine in Windows cmd when run through spack.
```
spack python
>>> import archspec
>>> archspec.cpu.host()
Microarchitecture('x86_64', [], 'generic', set(), {'gcc': [{'versions': '4.2.0:', 'name': 'x86-64', 'flags': '-march={name} -mtune=generic'}, {'versions': ':4.1.2', 'name': 'x86-64', 'flags': '-march={name} -mtune={name}'}], 'apple-clang': [{'versions': ':', 'name': 'x86-64', 'flags': '-march={name}'}], 'clang': [{'versions': ':', 'name': 'x86-64', 'flags': '-march={name} -mtune=generic'}], 'aocc': [{'versions': '2.2:', 'name': 'x86-64', 'flags': '-march={name} -mtune=generic'}], 'intel': [{'versions': ':', 'name': 'pentium4', 'flags': '-march={name} -mtune=generic'}], 'oneapi': [{'versions': ':', 'name': 'x86-64', 'flags': '-march={name} -mtune=generic'}], 'dpcpp': [{'versions': ':', 'name': 'x86-64', 'flags': '-march={name} -mtune=generic'}]}, 0)
```

Current limitations in this implementation:  The WSL output provides many more microarchitectures to choose from. These microarchitectures are not included because of [this line](https://github.com/markus-ferrell/archspec/blob/70122212dd05ee903559a2e814ee2065105f85df/archspec/cpu/detect.py#L356). I have not found a matching list on windows for these cpu flags.