### PR TITLE
parse non-int versions as 0 instead of raising

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -236,8 +236,15 @@ class Microarchitecture:
             version, _ = version_components(version)
 
             # Assume compiler versions fit into semver
+            # Anything that doesn't parse as an int will be treated as 0
+            def intify(ver):
+                try:
+                    return int(y)
+                except ValueError:
+                    return 0
+
             def tuplify(ver):
-                return tuple(int(y) for y in ver.split("."))
+                return tuple(intify(y) for y in ver.split("."))
 
             version = tuplify(version)
             if min_version:


### PR DESCRIPTION
Currently, in Spack if we fail to parse the version as reported from the compiler, we pass the user-given version info to archspec. If that user-generated information is non-numeric, archspec raises an error.

With this PR, archspec will interpret any non-numeric version component as 0. This will come much closer to accurately handling user requests.