### PR TITLE
Add an option to return x86_64 info under Rossetta2 on macOS

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -82,7 +82,7 @@ def _machine():
 
 
 def _using_rossetta():
-    """ Return whether we are using x86_64 emulation on Darwin"""
+    """Return whether we are using x86_64 emulation on Darwin"""
     operating_system = platform.system()
 
     if operating_system != "Darwin":
@@ -104,8 +104,9 @@ def sysctl_info_dict(use_python_arch):
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
     def sysctl_arch(arch, *args):
-        return _check_output(["arch", f"-{arch}", "sysctl"] + list(args),
-                             env=child_environment).strip()
+        return _check_output(
+            ["arch", f"-{arch}", "sysctl"] + list(args), env=child_environment
+        ).strip()
 
     if _machine() == "x86_64" and (not _using_rosetta() or use_python_arch):
         if _using_rossetta():

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -68,10 +68,7 @@ def expected_target(request, monkeypatch):
     cpu = archspec.cpu
     platform, operating_system, target = request.param.split("-")
 
-    # This is the default to use for tests on Darwin, since it will match
-    # Intel based MacBook, and will be the worst case scenario for Apple M1
-    # (i.e. Python for x86_64 running on top of Rosetta)
-    architecture_family = "x86_64" if platform == "darwin" else archspec.cpu.TARGETS[target].family
+    architecture_family = archspec.cpu.TARGETS[target].family
     if platform == "windows":
         architecture_family = "AMD64" if architecture_family == "x86_64" else "ARM64"
 


### PR DESCRIPTION
Fixes https://github.com/archspec/archspec/issues/133