### PR TITLE
Allow specifying a user defined JSON file

### DIFF
--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -46,7 +46,11 @@ def _make_parser() -> argparse.ArgumentParser:
 
 def cpu() -> int:
     """Run the `archspec cpu` subcommand."""
-    print(archspec.cpu.host())
+    try:
+        print(archspec.cpu.host())
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
     return 0
 
 

--- a/archspec/cpu/schema.py
+++ b/archspec/cpu/schema.py
@@ -7,7 +7,9 @@ JSON file and its schema
 """
 import collections.abc
 import json
-import os.path
+import os
+import pathlib
+from typing import Tuple
 
 
 class LazyDictionary(collections.abc.MutableMapping):
@@ -46,27 +48,65 @@ class LazyDictionary(collections.abc.MutableMapping):
         return len(self.data)
 
 
-def _load_json_file(json_file):
-    json_dir = os.path.join(os.path.dirname(__file__), "..", "json", "cpu")
-    json_dir = os.path.abspath(json_dir)
+#: Environment variable that might point to a directory with a user defined JSON file
+DIR_FROM_ENVIRONMENT = "ARCHSPEC_CPU_DIR"
 
-    def _factory():
-        filename = os.path.join(json_dir, json_file)
-        with open(filename, "r", encoding="utf-8") as file:
-            return json.load(file)
+#: Environment variable that might point to a directory with extensions to JSON files
+EXTENSION_DIR_FROM_ENVIRONMENT = "ARCHSPEC_EXTENSION_CPU_DIR"
 
-    return _factory
+
+def _json_file(filename: str, allow_custom: bool = False) -> Tuple[pathlib.Path, pathlib.Path]:
+    """Given a filename, returns the absolute path for the main JSON file, and an
+    optional absolute path for an extension JSON file.
+
+    Args:
+        filename: filename for the JSON file
+        allow_custom: if True, allows overriding the location  where the file resides
+    """
+    json_dir = pathlib.Path(__file__).parent / ".." / "json" / "cpu"
+    if allow_custom and DIR_FROM_ENVIRONMENT in os.environ:
+        json_dir = pathlib.Path(os.environ[DIR_FROM_ENVIRONMENT])
+    json_dir = json_dir.absolute()
+    json_file = json_dir / filename
+
+    extension_file = None
+    if allow_custom and EXTENSION_DIR_FROM_ENVIRONMENT in os.environ:
+        extension_dir = pathlib.Path(os.environ[EXTENSION_DIR_FROM_ENVIRONMENT])
+        extension_dir.absolute()
+        extension_file = extension_dir / filename
+
+    return json_file, extension_file
+
+
+def _load(json_file: pathlib.Path, extension_file: pathlib.Path):
+    with open(json_file, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    if not extension_file or not extension_file.exists():
+        return data
+
+    with open(extension_file, "r", encoding="utf-8") as file:
+        extension_data = json.load(file)
+
+    top_level_sections = list(data.keys())
+    for key in top_level_sections:
+        if key not in extension_data:
+            continue
+
+        data[key].update(extension_data[key])
+
+    return data
 
 
 #: In memory representation of the data in microarchitectures.json,
 #: loaded on first access
-TARGETS_JSON = LazyDictionary(_load_json_file("microarchitectures.json"))
+TARGETS_JSON = LazyDictionary(_load, *_json_file("microarchitectures.json", allow_custom=True))
 
 #: JSON schema for microarchitectures.json, loaded on first access
-TARGETS_JSON_SCHEMA = LazyDictionary(_load_json_file("microarchitectures_schema.json"))
+TARGETS_JSON_SCHEMA = LazyDictionary(_load, *_json_file("microarchitectures_schema.json"))
 
 #: Information on how to call 'cpuid' to get information on the HOST CPU
-CPUID_JSON = LazyDictionary(_load_json_file("cpuid.json"))
+CPUID_JSON = LazyDictionary(_load, *_json_file("cpuid.json", allow_custom=True))
 
 #: JSON schema for cpuid.json, loaded on first access
-CPUID_JSON_SCHEMA = LazyDictionary(_load_json_file("cpuid_schema.json"))
+CPUID_JSON_SCHEMA = LazyDictionary(_load, *_json_file("cpuid_schema.json"))

--- a/docs/source/microarchitectures.rst
+++ b/docs/source/microarchitectures.rst
@@ -73,6 +73,35 @@ instructions, but the actual labels might differ a bit to enhance their readabil
 On top of this static information ``archspec`` provides language bindings with logic to
 detect, query and compare different microarchitectures.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+User specified JSON database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users have two ways to customize the JSON files of ``archspec``. They can either set the ``ARCHSPEC_CPU_DIR``
+environment variable to a directory where they provide a *complete replacement* of all the JSON files expected
+by the package, or they can set the ``ARCHSPEC_EXTENSION_CPU_DIR`` environment variable to a directory where
+they can prepare JSON files containing only the items they need to add or override.
+
+In the latter case, the update of the default JSON files is done on the top-level attribute. This means, for
+instance, that a JSON file to add or override the ``pentium2`` architecture looks like the following:
+
+.. code-block:: json
+
+   {
+     "microarchitectures": {
+       "pentium2": {
+         "from": ["i686"],
+         "vendor": "GenuineIntel",
+         "features": [
+           "mmx"
+         ]
+       }
+     }
+   }
+
+This feature might be helpful when working with unreleased hardware, or when using virtualized environments
+that don't provide the same CPU flags as their corresponding bare metal counterpart.
+
 .. _cpu_host_detection:
 
 --------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+import archspec
+import archspec.cli
+import archspec.cpu
+import archspec.cpu.detect
+import archspec.cpu.microarchitecture
+import archspec.cpu.schema
+from archspec.cpu.microarchitecture import _known_microarchitectures
+from archspec.cpu.schema import LazyDictionary, _json_file, _load
+
+
+@pytest.fixture()
+def reset_global_state(monkeypatch):
+    """Returns a callable that resets the global state of archspec"""
+
+    def _func():
+        monkeypatch.setattr(
+            archspec.cpu.schema,
+            "TARGETS_JSON",
+            LazyDictionary(_load, *_json_file("microarchitectures.json", allow_custom=True)),
+        )
+        monkeypatch.setattr(archspec.cpu.detect, "TARGETS_JSON", archspec.cpu.schema.TARGETS_JSON)
+        monkeypatch.setattr(
+            archspec.cpu.schema,
+            "CPUID_JSON",
+            LazyDictionary(_load, *_json_file("cpuid.json", allow_custom=True)),
+        )
+        monkeypatch.setattr(archspec.cpu.detect, "CPUID_JSON", archspec.cpu.schema.TARGETS_JSON)
+        monkeypatch.setattr(
+            archspec.cpu.microarchitecture,
+            "TARGETS",
+            LazyDictionary(_known_microarchitectures),
+        )
+        monkeypatch.setattr(
+            archspec.cpu.detect,
+            "TARGETS",
+            archspec.cpu.microarchitecture.TARGETS,
+        )
+        monkeypatch.setattr(
+            archspec.cpu,
+            "TARGETS",
+            archspec.cpu.microarchitecture.TARGETS,
+        )
+
+    return _func

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,9 @@ import pytest
 
 import archspec
 import archspec.cli
+import archspec.cpu.detect
+import archspec.cpu.microarchitecture
+import archspec.cpu.schema
 
 
 @pytest.mark.parametrize("cli_args", [("--help",), ("cpu", "--help"), ("cpu",)])
@@ -22,3 +25,13 @@ def test_cli_version():
         result = archspec.cli.main(["--version"])
     assert result == 0
     assert stdout.getvalue() == "archspec, version " + archspec.__version__ + "\n"
+
+
+def test_cli_error_json_not_exist(monkeypatch, reset_global_state):
+    """Tests that when the environment variable ARCHSPEC_CPU_DIR points to a
+    wrong location, a comprehensible error message is printed and the return code is non-zero.
+    """
+    monkeypatch.setenv("ARCHSPEC_CPU_DIR", "/foo")
+    reset_global_state()
+    result = archspec.cli.main(["cpu"])
+    assert result != 0


### PR DESCRIPTION
fixes #144 

Users can now specify in the environment variable `ARCHSPEC_CPU_DIR` a custom directory where to find a complete replacement of the JSON files expected by `archspec`.

Likewise, they can set `ARCHSPEC_EXTENSION_CPU_DIR` to a directory where extension to the default JSON files are found.