### PR TITLE
Refactor and clean-up of detection

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -9,9 +9,9 @@ import platform
 import re
 import subprocess
 import warnings
-from typing import Optional, Set, Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
-from .microarchitecture import TARGETS, generic_microarchitecture, Microarchitecture
+from .microarchitecture import TARGETS, Microarchitecture, generic_microarchitecture
 from .schema import TARGETS_JSON
 
 #: Mapping from operating systems to chain of commands

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -113,6 +113,7 @@ def sysctl_info_dict():
             "model": sysctl("-n", "machdep.cpu.model"),
             "model name": sysctl("-n", "machdep.cpu.brand_string"),
         }
+        canonicalize_x86_64_darwin_flags(info)
     else:
         model = "unknown"
         model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
@@ -145,7 +146,7 @@ def _ensure_bin_usrbin_in_path():
     return child_environment
 
 
-def adjust_raw_flags(info):
+def canonicalize_x86_64_darwin_flags(info):
     """Adjust the flags detected on the system to homogenize
     slightly different representations.
     """
@@ -190,7 +191,6 @@ def raw_info_dictionary():
             warnings.warn(str(exc))
 
         if info:
-            adjust_raw_flags(info)
             adjust_raw_vendor(info)
             break
 

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -48,7 +48,7 @@ class Microarchitecture:
             which has "broadwell" as a parent, supports running binaries
             optimized for "broadwell".
         vendor (str): vendor of the micro-architecture
-        features (list of str): supported CPU flags. Note that the semantic
+        features (set of str): supported CPU flags. Note that the semantic
             of the flags in this field might vary among architectures, if
             at all present. For instance x86_64 processors will list all
             the flags supported by a given CPU while Arm processors will


### PR DESCRIPTION
This refactor cleans up the code performing detection. The main change is that, when scraping a system for information on a CPU, functions will return a "partial" `Microarchitecture` object, instead of a dict of strings with non-well defined keys.

This refactoring allowed to cache some computations, so it also speeds-up detection (for people who like micro optimizatons). On this branch, on my `icelake` laptop:
```console
$ python -m timeit -s "import archspec.cpu.detect" -- "archspec.cpu.detect.host()"
1000 loops, best of 5: 211 usec per loop
```
while on `develop`:
```console
$ python -m timeit -s "import archspec.cpu.detect" -- "archspec.cpu.detect.host()"
500 loops, best of 5: 820 usec per loop
```
