### PR TITLE
Fix submitting coverage to codecov

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
   py36:
@@ -66,5 +67,6 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
This is needed with the latest version of `codecov-action`, though nothing failed in CI during the update.