### PR TITLE
Add a `Microarchitecture.from_dict` constructor

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -181,24 +181,28 @@ class Microarchitecture:
         generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
         return max(generics, key=lambda x: len(x.ancestors))
 
-    def to_dict(self, return_list_of_items=False):
-        """Returns a dictionary representation of this object.
+    def to_dict(self):
+        """Returns a dictionary representation of this object."""
+        return {
+            "name": str(self.name),
+            "vendor": str(self.vendor),
+            "features": sorted(str(x) for x in self.features),
+            "generation": self.generation,
+            "parents": [str(x) for x in self.parents],
+            "compilers": self.compilers,
+        }
 
-        Args:
-            return_list_of_items (bool): if True returns an ordered list of
-                items instead of the dictionary
-        """
-        list_of_items = [
-            ("name", str(self.name)),
-            ("vendor", str(self.vendor)),
-            ("features", sorted(str(x) for x in self.features)),
-            ("generation", self.generation),
-            ("parents", [str(x) for x in self.parents]),
-        ]
-        if return_list_of_items:
-            return list_of_items
-
-        return dict(list_of_items)
+    @staticmethod
+    def from_dict(data) -> "Microarchitecture":
+        """Construct a microarchitecture from a dictionary representation."""
+        return Microarchitecture(
+            name=data["name"],
+            parents=[TARGETS[x] for x in data["parents"]],
+            vendor=data["vendor"],
+            features=set(data["features"]),
+            compilers=data.get("compilers", {}),
+            generation=data.get("generation", 0),
+        )
 
     def optimization_flags(self, compiler, version):
         """Returns a string containing the optimization flags that needs

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -422,3 +422,9 @@ def test_versions_are_ranges(supported_target):
     for compiler_name, entries in target_under_test.compilers.items():
         for compiler_info in entries:
             assert ":" in compiler_info["versions"]
+
+
+def test_round_trip_dict():
+    for name in archspec.cpu.TARGETS:
+        uarch_copy = Microarchitecture.from_dict(archspec.cpu.TARGETS[name].to_dict())
+        assert uarch_copy == archspec.cpu.TARGETS[name]


### PR DESCRIPTION
fixes #139

Also, removes questionable argument from the `Microarchitecture.to_dict` method