### PR TITLE
Improve Microarchitecture.optimization_flags errors

### DIFF
--- a/archspec/cpu/__init__.py
+++ b/archspec/cpu/__init__.py
@@ -8,6 +8,7 @@ CPU microarchitectures.
 from .detect import brand_string, host
 from .microarchitecture import (
     TARGETS,
+    InvalidCompilerVersion,
     Microarchitecture,
     UnsupportedMicroarchitecture,
     generic_microarchitecture,
@@ -15,11 +16,12 @@ from .microarchitecture import (
 )
 
 __all__ = [
+    "brand_string",
+    "host",
+    "TARGETS",
+    "InvalidCompilerVersion",
     "Microarchitecture",
     "UnsupportedMicroarchitecture",
-    "TARGETS",
     "generic_microarchitecture",
-    "host",
     "version_components",
-    "brand_string",
 ]

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -240,7 +240,7 @@ class Microarchitecture:
             raise UnsupportedMicroarchitecture(msg)
 
         # Check that the version matches the expected format
-        if not re.match(r"^(?:\d+.)*\d+$", version):
+        if not re.match(r"^(?:\d+\.)*\d+$", version):
             msg = "wrong format for the version argument. Only dot separated digits are allowed."
             raise ValueError(msg)
 

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -208,6 +208,8 @@ class Microarchitecture:
         """Returns a string containing the optimization flags that needs
         to be used to produce code optimized for this micro-architecture.
 
+        The version is expected to be a string of dot separated digits.
+
         If there is no information on the compiler passed as argument the
         function returns an empty string. If it is known that the compiler
         version we want to use does not support this architecture the function
@@ -216,6 +218,11 @@ class Microarchitecture:
         Args:
             compiler (str): name of the compiler to be used
             version (str): version of the compiler to be used
+
+        Raises:
+            UnsupportedMicroarchitecture: if the requested compiler does not support
+                this micro-architecture.
+            ValueError: if the version doesn't match the expected format
         """
         # If we don't have information on compiler at all return an empty string
         if compiler not in self.family.compilers:
@@ -231,6 +238,11 @@ class Microarchitecture:
             )
             msg = msg.format(compiler, best_target, best_target.family)
             raise UnsupportedMicroarchitecture(msg)
+
+        # Check that the version matches the expected format
+        if not re.match(r"^(?:\d+.)*\d+$", version):
+            msg = "wrong format for the version argument. Only dot separated digits are allowed."
+            raise ValueError(msg)
 
         # If we have information on this compiler we need to check the
         # version being used

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -387,7 +387,9 @@ class ArchspecError(Exception):
 
 
 class UnsupportedMicroarchitecture(ArchspecError, ValueError):
-    """Raised if a compiler version does not support optimization for a given micro-architecture."""
+    """Raised if a compiler version does not support optimization for a given
+    micro-architecture.
+    """
 
 
 class InvalidCompilerVersion(ArchspecError, ValueError):

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -245,7 +245,7 @@ class Microarchitecture:
                 "invalid format for the compiler version argument. "
                 "Only dot separated digits are allowed."
             )
-            raise ValueError(msg)
+            raise InvalidCompilerVersion(msg)
 
         # If we have information on this compiler we need to check the
         # version being used
@@ -382,7 +382,13 @@ def _known_microarchitectures():
 TARGETS = LazyDictionary(_known_microarchitectures)
 
 
-class UnsupportedMicroarchitecture(ValueError):
-    """Raised if a compiler version does not support optimization for a given
-    micro-architecture.
-    """
+class ArchspecError(Exception):
+    """Base class for errors within archspec"""
+
+
+class UnsupportedMicroarchitecture(ArchspecError, ValueError):
+    """Raised if a compiler version does not support optimization for a given micro-architecture."""
+
+
+class InvalidCompilerVersion(ArchspecError, ValueError):
+    """Raised when an invalid format is used for compiler versions in archspec."""

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -241,7 +241,7 @@ class Microarchitecture:
 
         # Check that the version matches the expected format
         if not re.match(r"^(?:\d+\.)*\d+$", version):
-            msg = "wrong format for the version argument. Only dot separated digits are allowed."
+            msg = "invalid format for the compiler version argument. Only dot separated digits are allowed."
             raise ValueError(msg)
 
         # If we have information on this compiler we need to check the

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -241,7 +241,10 @@ class Microarchitecture:
 
         # Check that the version matches the expected format
         if not re.match(r"^(?:\d+\.)*\d+$", version):
-            msg = "invalid format for the compiler version argument. Only dot separated digits are allowed."
+            msg = (
+                "invalid format for the compiler version argument. "
+                "Only dot separated digits are allowed."
+            )
             raise ValueError(msg)
 
         # If we have information on this compiler we need to check the

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -522,5 +522,5 @@ def test_error_message_unknown_compiler_version(version_str):
     raises a comprehensible error message.
     """
     t = archspec.cpu.TARGETS["icelake"]
-    with pytest.raises(ValueError, match="wrong format for the version argument"):
+    with pytest.raises(ValueError, match="invalid format for the compiler version argument"):
         t.optimization_flags("gcc", version_str)

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -508,3 +508,19 @@ def test_only_one_extension_file(extension_file, monkeypatch, reset_global_state
 
 def test_brand_string(expected_brand_string):
     assert archspec.cpu.detect.brand_string() == expected_brand_string
+
+
+@pytest.mark.parametrize(
+    "version_str",
+    [
+        "13.2.0.debug",
+        "optimized",
+    ],
+)
+def test_error_message_unknown_compiler_version(version_str):
+    """Tests that passing a version to Microarchitecture.optimization_flags with a wrong format,
+    raises a comprehensible error message.
+    """
+    t = archspec.cpu.TARGETS["icelake"]
+    with pytest.raises(ValueError, match="wrong format for the version argument"):
+        t.optimization_flags("gcc", version_str)

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -522,5 +522,8 @@ def test_error_message_unknown_compiler_version(version_str):
     raises a comprehensible error message.
     """
     t = archspec.cpu.TARGETS["icelake"]
-    with pytest.raises(ValueError, match="invalid format for the compiler version argument"):
+    with pytest.raises(
+        archspec.cpu.InvalidCompilerVersion,
+        match="invalid format for the compiler version argument",
+    ):
         t.optimization_flags("gcc", version_str)


### PR DESCRIPTION
closes #120

This commit improves the error message of the exception raised when the version format, passed as input argument to `Microarchitecture.optimization_flags`, does not match the expected format (dot separated digits).