### PR TITLE
Add a function returning the brand string of the host

### DIFF
--- a/archspec/cpu/__init__.py
+++ b/archspec/cpu/__init__.py
@@ -5,7 +5,7 @@
 """The "cpu" package permits to query and compare different
 CPU microarchitectures.
 """
-from .detect import host
+from .detect import brand_string, host
 from .microarchitecture import (
     TARGETS,
     Microarchitecture,
@@ -21,4 +21,5 @@ __all__ = [
     "generic_microarchitecture",
     "host",
     "version_components",
+    "brand_string",
 ]

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -155,6 +155,31 @@ class CpuidInfoCollector:
         mask = 1 << bit
         return register & mask > 0
 
+    def brand_string(self) -> Optional[str]:
+        """Returns the branch string, if available."""
+        if self.highest_extension_support < 0x80000004:
+            return None
+
+        r1 = self.cpuid.registers_for(eax=0x80000002, ecx=0)
+        r2 = self.cpuid.registers_for(eax=0x80000003, ecx=0)
+        r3 = self.cpuid.registers_for(eax=0x80000004, ecx=0)
+        result = struct.pack(
+            "IIIIIIIIIIII",
+            r1.eax,
+            r1.ebx,
+            r1.ecx,
+            r1.edx,
+            r2.eax,
+            r2.ebx,
+            r2.ecx,
+            r2.edx,
+            r3.eax,
+            r3.ebx,
+            r3.ecx,
+            r3.edx,
+        ).decode("utf-8")
+        return result.strip("\x00")
+
 
 @detection(operating_system="Windows")
 def cpuid_info():
@@ -174,8 +199,8 @@ def _check_output(args, env):
 
 
 WINDOWS_MAPPING = {
-    "AMD64": "x86_64",
-    "ARM64": "aarch64",
+    "AMD64": X86_64,
+    "ARM64": AARCH64,
 }
 
 
@@ -409,3 +434,16 @@ def compatibility_check_for_riscv64(info, target):
     return (target == arch_root or arch_root in target.ancestors) and (
         target.name == info.name or target.vendor == "generic"
     )
+
+
+def brand_string() -> Optional[str]:
+    """Returns the brand string of the host, if detected, or None."""
+    if platform.system() == "Darwin":
+        return _check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"], env=_ensure_bin_usrbin_in_path()
+        ).strip()
+
+    if host().family == X86_64:
+        return CpuidInfoCollector().brand_string()
+
+    return None

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -156,7 +156,7 @@ class CpuidInfoCollector:
         return register & mask > 0
 
     def brand_string(self) -> Optional[str]:
-        """Returns the branch string, if available."""
+        """Returns the brand string, if available."""
         if self.highest_extension_support < 0x80000004:
             return None
 


### PR DESCRIPTION
This PR adds a function to return the brand string of the CPU:
```python
>>> import archspec.cpu
>>> archspec.cpu.brand_string()
'11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz'
```
It currently works on `x86_64` (all platforms), and `darwin` (all targets family). Linux `aarch64` is not covered yet.