### PR TITLE
Update neoverse-v2 detection

### DIFF
--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -58,6 +58,7 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "linux-rhel8-power9",
         "linux-unknown-power10",
         "linux-ubuntu22.04-neoverse_v2",
+        "linux-rhel9-neoverse_v2",
         "windows-cpuid-broadwell",
         "windows-cpuid-icelake",
     ]


### PR DESCRIPTION
Remove `paca`, `pacg` and `bti` from the list of required features