### PR TITLE
Remove Python 3.7 from macos-latest unit-tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,8 +16,12 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
+          - os: macos-13
+            python-version: '3.8'
+          - os: ubuntu-latest
+            python-version: '3.7'
           - os: windows-latest
             python-version: '3.8'
           - os: windows-latest

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -307,7 +307,7 @@ def generic_microarchitecture(name):
     Args:
         name (str): name of the micro-architecture
     """
-    return Microarchitecture(name, parents=[], vendor="generic", features=[], compilers={})
+    return Microarchitecture(name, parents=[], vendor="generic", features=set(), compilers={})
 
 
 def version_components(version):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -127,6 +127,7 @@ def expected_brand_string(request, monkeypatch):
         monkeypatch.setattr(archspec.cpu.detect.platform, "system", lambda: "Darwin")
         monkeypatch.setattr(archspec.cpu.detect, "_check_output", mock_check_output(filename))
     elif "cpuid" in test_file:
+        monkeypatch.setattr(archspec.cpu.detect, "host", lambda: archspec.cpu.TARGETS["x86_64"])
         monkeypatch.setattr(archspec.cpu.detect.platform, "system", lambda: "Windows")
         monkeypatch.setattr(archspec.cpu.detect, "CPUID", mock_CpuidInfoCollector(filename))
     return expected_result


### PR DESCRIPTION
The runner switched to macOS 14, and for that there is no Python 3.7 available from actions/setup-python