### PR TITLE
Pass name field for Arm cores in constructor of partial_uarch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "archspec/json"]
 	path = archspec/json
-	url = https://github.com/archspec/archspec-json.git
+	url = https://github.com/paolotricerri/archspec-json.git
 [submodule "archspec/vendor/cpuid"]
 	path = archspec/vendor/cpuid
 	url = https://github.com/archspec/cpuid.git

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -88,6 +88,7 @@ def proc_cpuinfo() -> Microarchitecture:
 
     if architecture == AARCH64:
         return partial_uarch(
+            name = _get_name_from_cpuid(data),
             vendor=_canonicalize_aarch64_vendor(data),
             features=_feature_set(data, key="Features"),
         )
@@ -294,6 +295,18 @@ def _canonicalize_aarch64_vendor(data: Dict[str, str]) -> str:
     arm_vendors = TARGETS_JSON["conversions"]["arm_vendors"]
     arm_code = data["CPU implementer"]
     return arm_vendors.get(arm_code, arm_code)
+
+
+def _get_name_from_cpuid(data: Dict[str, str]) -> str:
+    # This function is only called for AARCH64 architectures
+    cpu_impl = data.get("CPU implementer","")
+    cpu_part = data.get("CPU part", "")
+
+    cpuid = cpu_impl + cpu_part[2:]
+    for m_arch, properties in TARGETS_JSON["microarchitectures"].items():
+        if "cpuid" in properties.keys() and properties["cpuid"] == cpuid:
+            return m_arch
+    return ""
 
 
 def _feature_set(data: Dict[str, str], key: str) -> Set[str]:


### PR DESCRIPTION
This change addresses the change proposed in https://github.com/archspec/archspec/pull/168 where, for Arm cores, the name, deduced from the cpuid, could be passed to the constructor of `partial_uarch` that now can return a Microarchitecture with the appropriate name. 

This patch both updates the git submodule to archspec-json (which will have to be re-updated once the other PR will have been merged) as well as adds a test to make sure that the calculation of the name from the cpuid is correct.

CC: @dslarm