### PR TITLE
Use the "cpupart" field when detecting AArch64

### DIFF
--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -62,6 +62,7 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "windows-cpuid-broadwell",
         "windows-cpuid-icelake",
         "linux-rhel8-neoverse_v1",
+        "linux-unknown-neoverse_v2",
     ]
 )
 def expected_target(request, monkeypatch):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -64,6 +64,7 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "linux-rhel8-neoverse_v1",
         "linux-unknown-neoverse_v2",
         "linux-rhel9-neoverse_n2",
+        "linux-ubuntu22.04-neoverse_n2",
     ]
 )
 def expected_target(request, monkeypatch):

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -63,6 +63,7 @@ Microarchitecture = archspec.cpu.Microarchitecture
         "windows-cpuid-icelake",
         "linux-rhel8-neoverse_v1",
         "linux-unknown-neoverse_v2",
+        "linux-rhel9-neoverse_n2",
     ]
 )
 def expected_target(request, monkeypatch):


### PR DESCRIPTION
closes #170 

This commit changes the detection algorithm for AArch64 architectures, so that we also use `cpupart` when that information is available.