### PR TITLE
Allow using Microarchitecture in sets

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -115,6 +115,9 @@ class Microarchitecture:
             and self.cpu_part == other.cpu_part
         )
 
+    def __hash__(self):
+        return hash(self.name)
+
     @coerce_target_names
     def __ne__(self, other):
         return not self == other

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -533,3 +533,12 @@ def test_error_message_unknown_compiler_version(version_str):
         match="invalid format for the compiler version argument",
     ):
         t.optimization_flags("gcc", version_str)
+
+
+@pytest.mark.parametrize(
+    "names,expected_length",
+    [(("icelake", "broadwell"), 2), (("icelake", "broadwell", "icelake"), 2)],
+)
+def test_targets_can_be_used_in_sets(names, expected_length):
+    s = {archspec.cpu.TARGETS[name] for name in names}
+    assert len(s) == expected_length


### PR DESCRIPTION
Define a proper `Microarchitecture.__hash__`  to allow using uarch objects with sets, or as keys in dictionaries. 