### PR TITLE
Cache the "family" and "generic" computation

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -81,8 +81,13 @@ class Microarchitecture:
         self.generation = generation
         # Only relevant for AArch64
         self.cpu_part = cpu_part
-        # Cache the ancestor computation
+
+        # Cache the "ancestor" computation
         self._ancestors = None
+        # Cache the "generic" computation
+        self._generic = None
+        # Cache the "family" computation
+        self._family = None
 
     @property
     def ancestors(self):
@@ -174,18 +179,22 @@ class Microarchitecture:
     @property
     def family(self):
         """Returns the architecture family a given target belongs to"""
-        roots = [x for x in [self] + self.ancestors if not x.ancestors]
-        msg = "a target is expected to belong to just one architecture family"
-        msg += f"[found {', '.join(str(x) for x in roots)}]"
-        assert len(roots) == 1, msg
+        if self._family is None:
+            roots = [x for x in [self] + self.ancestors if not x.ancestors]
+            msg = "a target is expected to belong to just one architecture family"
+            msg += f"[found {', '.join(str(x) for x in roots)}]"
+            assert len(roots) == 1, msg
+            self._family = roots.pop()
 
-        return roots.pop()
+        return self._family
 
     @property
     def generic(self):
         """Returns the best generic architecture that is compatible with self"""
-        generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
-        return max(generics, key=lambda x: len(x.ancestors))
+        if self._generic is None:
+            generics = [x for x in [self] + self.ancestors if x.vendor == "generic"]
+            self._generic = max(generics, key=lambda x: len(x.ancestors))
+        return self._generic
 
     def to_dict(self):
         """Returns a dictionary representation of this object."""


### PR DESCRIPTION
This should help slightly, when these attributes are queried frequently by clients. 

**Before**
```console
$ python -m timeit -s "import archspec.cpu" "s = {key: uarch.family for key, uarch in archspec.cpu.TARGETS.items()}"
2000 loops, best of 5: 152 usec per loop
$ python -m timeit -s "import archspec.cpu" "s = {key: uarch.generic for key, uarch in archspec.cpu.TARGETS.items()}"
2000 loops, best of 5: 126 usec per loop
```

**After**
```console
$ python -m timeit -s "import archspec.cpu" "s = {key: uarch.family for key, uarch in archspec.cpu.TARGETS.items()}"
10000 loops, best of 5: 22 usec per loop
$ python -m timeit -s "import archspec.cpu" "s = {key: uarch.generic for key, uarch in archspec.cpu.TARGETS.items()}"
10000 loops, best of 5: 21.4 usec per loop
```