### PR TITLE
Run Python 3.7 unit tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: macos-13
             python-version: '3.8'
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python-version: '3.7'
           - os: windows-latest
             python-version: '3.8'


### PR DESCRIPTION
Python 3.7 is EoL already, and not supported on Ubuntu 24.04