### PR TITLE
microarchitecture.py: make `__repr__` brief, add `tree`

### DIFF
--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -163,7 +163,7 @@ class Microarchitecture:
         stack: List[Tuple[int, Microarchitecture]] = [(0, self)]
         while stack:
             level, current = stack.pop()
-            print(f"{'':{level}}{current.name}", file=fp)
+            print(f"{'':>{level}}{current.name}", file=fp)
 
             if current.name in seen:
                 continue

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -6,6 +6,7 @@
 import contextlib
 import csv
 import os.path
+from io import StringIO
 from typing import NamedTuple
 
 import jsonschema
@@ -15,9 +16,7 @@ import archspec.cpu
 import archspec.cpu.alias
 import archspec.cpu.detect
 import archspec.cpu.schema
-
-# This is needed to check that with repr we could create equivalent objects
-Microarchitecture = archspec.cpu.Microarchitecture
+from archspec.cpu import Microarchitecture
 
 
 @pytest.fixture(
@@ -216,7 +215,17 @@ def test_str_conversion(supported_target):
 
 def test_repr_conversion(supported_target):
     target = archspec.cpu.TARGETS[supported_target]
-    assert eval(repr(target)) == target
+    assert f"Microarchitecture({supported_target!r})" == repr(target)
+
+
+def test_tree(supported_target):
+    buffer = StringIO()
+    target = archspec.cpu.TARGETS[supported_target]
+    target.tree(buffer, indent=2)
+    tree_lines = buffer.getvalue().splitlines()
+    assert tree_lines[0].startswith(supported_target)
+    for parent in target.parents:
+        assert any(line.startswith(f"  {parent.name}") for line in tree_lines)
 
 
 def test_equality(supported_target):


### PR DESCRIPTION
Previously Microarchitecture.__repr__ would indeed result in something that round-tripped eval(repr(x)) == x, but in practice it's incredibly verbose, and clutters the repl when looking at Spec objects in Spack.

Instead, it now just prints `Microarchitecture("<name>")` which doesn't round-trip, but is easier for humans.

Also add a helper `.tree()`, which looks like this, where every line is a unique microarch, and nesting means parent and child are ordered.

```
In [1]: from spack.spec import Spec

In [2]: Spec("target=broadwell").target.tree()
broadwell
    haswell
        ivybridge
            sandybridge
                westmere
                    nehalem
                        core2
                            nocona
                                x86_64
                        x86_64_v2
                            x86_64
        x86_64_v3
            x86_64_v2
                x86_64
```