### PR TITLE
tests: ensure feature subset semantics for partial order on uarchs

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -254,14 +254,15 @@ def sysctl_info() -> Microarchitecture:
     if _machine() == X86_64:
         raw_features = (
             f'{sysctl("-n", "machdep.cpu.features").lower()} '
-            f'{sysctl("-n", "machdep.cpu.leaf7_features").lower()}'
+            f'{sysctl("-n", "machdep.cpu.leaf7_features").lower()} '
+            f'{sysctl("-n", "machdep.cpu.extfeatures").lower()}'
         )
         features = set(raw_features.split())
 
         # Flags detected on Darwin turned to their linux counterpart
-        for darwin_flag, linux_flag in TARGETS_JSON["conversions"]["darwin_flags"].items():
-            if darwin_flag in features:
-                features.update(linux_flag.split())
+        for darwin_flags, linux_flags in TARGETS_JSON["conversions"]["darwin_flags"].items():
+            if all(x in features for x in darwin_flags.split()):
+                features.update(linux_flags.split())
 
         return partial_uarch(vendor=sysctl("-n", "machdep.cpu.vendor"), features=features)
 

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -249,15 +249,16 @@ def sysctl_info() -> Microarchitecture:
     child_environment = _ensure_bin_usrbin_in_path()
 
     def sysctl(*args: str) -> str:
-        return _check_output(["sysctl"] + list(args), env=child_environment).strip()
+        return _check_output(["sysctl", *args], env=child_environment).strip()
 
     if _machine() == X86_64:
-        raw_features = (
-            f'{sysctl("-n", "machdep.cpu.features").lower()} '
-            f'{sysctl("-n", "machdep.cpu.leaf7_features").lower()} '
-            f'{sysctl("-n", "machdep.cpu.extfeatures").lower()}'
+        raw_features = sysctl(
+            "-n",
+            "machdep.cpu.features",
+            "machdep.cpu.leaf7_features",
+            "machdep.cpu.extfeatures",
         )
-        features = set(raw_features.split())
+        features = set(raw_features.lower().split())
 
         # Flags detected on Darwin turned to their linux counterpart
         for darwin_flags, linux_flags in TARGETS_JSON["conversions"]["darwin_flags"].items():

--- a/archspec/cpu/microarchitecture.py
+++ b/archspec/cpu/microarchitecture.py
@@ -93,6 +93,10 @@ class Microarchitecture:
         # Cache the "family" computation
         self._family: Optional["Microarchitecture"] = None
 
+        # ssse3 implies sse3; on Linux sse3 is not mentioned in /proc/cpuinfo, so add it ad-hoc.
+        if "ssse3" in self.features:
+            self.features.add("sse3")
+
     @property
     def ancestors(self) -> List["Microarchitecture"]:
         """All the ancestors of this microarchitecture."""

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -284,17 +284,10 @@ def test_partial_order_from_powerset_of_features():
     # If A is the set of CPU features, then the powerset P(A) is the set of all microarchitectures.
     # We define the usual partial order on P(A) as X <= Y if X is a subset of Y. Here we verify
     # that this partial order is respected by the microarchitectures.
-    fail = False
     for child in archspec.cpu.TARGETS.values():
         for parent in child.parents:
-            # parent <= child by definition
             assert parent <= child
-
-            # test <= has subset semantics on the set of features
-            if not parent.features.issubset(child.features):
-                print(f"{parent} <= {child} fails: {', '.join(parent.features - child.features)}")
-                fail = True
-    assert not fail, "Microarchitectures do not follow feature subset semantics"
+            assert parent.features.issubset(child.features)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -143,8 +143,7 @@ def mock_check_output(filename):
             info[key.strip()] = value.strip()
 
     def _check_output(args, env):
-        current_key = args[-1]
-        return info[current_key]
+        return "\n".join(info[key] for key in args[1:] if not key.startswith("-"))
 
     return _check_output
 

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -280,6 +280,23 @@ def test_partial_ordering(operation, expected_result):
     assert eval(code) is expected_result
 
 
+def test_partial_order_from_powerset_of_features():
+    # If A is the set of CPU features, then the powerset P(A) is the set of all microarchitectures.
+    # We define the usual partial order on P(A) as X <= Y if X is a subset of Y. Here we verify
+    # that this partial order is respected by the microarchitectures.
+    fail = False
+    for child in archspec.cpu.TARGETS.values():
+        for parent in child.parents:
+            # parent <= child by definition
+            assert parent <= child
+
+            # test <= has subset semantics on the set of features
+            if not parent.features.issubset(child.features):
+                print(f"{parent} <= {child} fails: {', '.join(parent.features - child.features)}")
+                fail = True
+    assert not fail, "Microarchitectures do not follow feature subset semantics"
+
+
 @pytest.mark.parametrize(
     "target_name,expected_family",
     [


### PR DESCRIPTION
closes #211

If A is the set of CPU features, then the powerset P(A) is the set of uarchs, for which the natural partial order is X ≤ Y iff X ⊆ Y.

A test ensuring this definition of ≤ is added. `microarchitectures.json` was updated to fix various issues uncovered by it, mostly missing `lahf_lm`, `cx16`, `xsave`, `abm`, `pku`, as well as `sha_ni` being incorrectly named `sha`.