### PR TITLE
Remove the `linux-amazon2-sapphirerapids` test target

### DIFF
--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -52,7 +52,6 @@ from archspec.cpu import Microarchitecture
         "linux-asahi-m2",
         "darwin-monterey-m2",
         "linux-rocky8-a64fx",
-        "linux-amazon2-sapphirerapids",
         "linux-unknown-sapphirerapids",
         "linux-rhel8-power9",
         "linux-unknown-power10",


### PR DESCRIPTION
Based on
https://github.com/archspec/archspec-json/pull/127#issuecomment-2821100759, this test json is missing several features and therefore not representative of an actual SPR machine.

There's a remaining test for SPR (`linux-unknown-sapphirerapids`), so simply remove this one.