### PR TITLE
Add support for M5 and presumably future architectures

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -269,16 +269,10 @@ def sysctl_info() -> Microarchitecture:
 
     model = "unknown"
     model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
-    if "m4" in model_str:
-        model = "m4"
-    elif "m3" in model_str:
-        model = "m3"
-    elif "m2" in model_str:
-        model = "m2"
-    elif "m1" in model_str:
-        model = "m1"
-    elif "apple" in model_str:
-        model = "m1"
+    # Example brand string: 'Apple M5'
+    match = re.search("m[1-5]", model_str)
+    if match is not None:
+        model = match.group(0)
 
     return partial_uarch(name=model, vendor="Apple")
 

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -66,6 +66,7 @@ from archspec.cpu import Microarchitecture
         "linux-rocky9-zen5",
         "darwin-sequoia-m3",
         "darwin-sequoia-m4",
+        "darwin-tahoe-m5",
     ]
 )
 def expected_target(request, monkeypatch):
@@ -120,6 +121,7 @@ def targets_directory():
         ("darwin-mojave-skylake", "Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"),
         ("darwin-monterey-m1", "Apple M1 Pro"),
         ("darwin-monterey-m2", "Apple M2"),
+        ("darwin-tahoe-m5", "Apple M5"),
         ("windows-cpuid-broadwell", "Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz"),
         ("windows-cpuid-icelake", "11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz"),
     ]


### PR DESCRIPTION
Tested on my new Macbook Pro M5.
```console
$ sysctl hw machdep
hw.ncpu: 10
hw.byteorder: 1234
hw.memsize: 25769803776
hw.activecpu: 10
hw.features.allows_security_research: 0
hw.optional.arm.FEAT_CRC32: 1
hw.optional.arm.FEAT_FlagM: 1
hw.optional.arm.FEAT_FlagM2: 1
hw.optional.arm.FEAT_FHM: 1
hw.optional.arm.FEAT_DotProd: 1
hw.optional.arm.FEAT_SHA3: 1
hw.optional.arm.FEAT_RDM: 1
hw.optional.arm.FEAT_LSE: 1
hw.optional.arm.FEAT_SHA256: 1
hw.optional.arm.FEAT_SHA512: 1
hw.optional.arm.FEAT_SHA1: 1
hw.optional.arm.FEAT_AES: 1
hw.optional.arm.FEAT_PMULL: 1
hw.optional.arm.FEAT_SPECRES: 0
hw.optional.arm.FEAT_SPECRES2: 0
hw.optional.arm.FEAT_SB: 1
hw.optional.arm.FEAT_FRINTTS: 1
hw.optional.arm.FEAT_PACIMP: 1
hw.optional.arm.FEAT_LRCPC: 1
hw.optional.arm.FEAT_LRCPC2: 1
hw.optional.arm.FEAT_FCMA: 1
hw.optional.arm.FEAT_JSCVT: 1
hw.optional.arm.FEAT_PAuth: 1
hw.optional.arm.FEAT_PAuth2: 1
hw.optional.arm.FEAT_FPAC: 1
hw.optional.arm.FEAT_FPACCOMBINE: 1
hw.optional.arm.FEAT_DPB: 1
hw.optional.arm.FEAT_DPB2: 1
hw.optional.arm.FEAT_BF16: 1
hw.optional.arm.FEAT_EBF16: 1
hw.optional.arm.FEAT_I8MM: 1
hw.optional.arm.FEAT_WFxT: 1
hw.optional.arm.FEAT_RPRES: 1
hw.optional.arm.FEAT_CSSC: 1
hw.optional.arm.FEAT_HBC: 1
hw.optional.arm.FEAT_ECV: 1
hw.optional.arm.FEAT_AFP: 1
hw.optional.arm.FEAT_LSE2: 1
hw.optional.arm.FEAT_CSV2: 1
hw.optional.arm.FEAT_CSV3: 1
hw.optional.arm.FEAT_DIT: 1
hw.optional.arm.AdvSIMD: 1
hw.optional.arm.AdvSIMD_HPFPCvt: 1
hw.optional.arm.FEAT_FP16: 1
hw.optional.arm.FEAT_SSBS: 0
hw.optional.arm.FEAT_BTI: 1
hw.optional.arm.FEAT_SME: 1
hw.optional.arm.FEAT_SME2: 1
hw.optional.arm.FEAT_SME2p1: 1
hw.optional.arm.FEAT_MTE: 1
hw.optional.arm.FEAT_MTE2: 1
hw.optional.arm.FEAT_MTE3: 0
hw.optional.arm.FEAT_MTE4: 1
hw.optional.arm.FEAT_MTE_ASYNC: 0
hw.optional.arm.FEAT_MTE_STORE_ONLY: 1
hw.optional.arm.SME_F32F32: 1
hw.optional.arm.SME_BI32I32: 1
hw.optional.arm.SME_B16F32: 1
hw.optional.arm.SME_F16F32: 1
hw.optional.arm.SME_I8I32: 1
hw.optional.arm.SME_I16I32: 1
hw.optional.arm.FEAT_SME_F64F64: 1
hw.optional.arm.FEAT_SME_I16I64: 1
hw.optional.arm.FEAT_SME_F16F16: 1
hw.optional.arm.FEAT_SME_B16B16: 1
hw.optional.arm.FP_SyncExceptions: 1
hw.optional.arm.FEAT_MTE_CANONICAL_TAGS: 1
hw.optional.arm.FEAT_MTE_NO_ADDRESS_TAGS: 1
hw.optional.arm.caps: -4612108402691149825
hw.optional.arm.sme_max_svl_b: 64
hw.optional.floatingpoint: 1
hw.optional.neon: 1
hw.optional.neon_hpfp: 1
hw.optional.neon_fp16: 1
hw.optional.armv8_crc32: 1
hw.optional.armv8_gpi: 1
hw.optional.armv8_1_atomics: 1
hw.optional.armv8_2_fhm: 1
hw.optional.armv8_2_sha512: 1
hw.optional.armv8_2_sha3: 1
hw.optional.armv8_3_compnum: 1
hw.optional.watchpoint: 4
hw.optional.breakpoint: 6
hw.optional.ucnormal_mem: 1
hw.optional.arm64: 1
hw.perflevel1.physicalcpu: 6
hw.perflevel1.physicalcpu_max: 6
hw.perflevel1.logicalcpu: 6
hw.perflevel1.logicalcpu_max: 6
hw.perflevel1.l1icachesize: 131072
hw.perflevel1.l1dcachesize: 65536
hw.perflevel1.l2cachesize: 6291456
hw.perflevel1.cpusperl2: 6
hw.perflevel1.name: Efficiency
hw.perflevel0.physicalcpu: 4
hw.perflevel0.physicalcpu_max: 4
hw.perflevel0.logicalcpu: 4
hw.perflevel0.logicalcpu_max: 4
hw.perflevel0.l1icachesize: 196608
hw.perflevel0.l1dcachesize: 131072
hw.perflevel0.l2cachesize: 16777216
hw.perflevel0.cpusperl2: 4
hw.perflevel0.name: Performance
hw.physicalcpu: 10
hw.physicalcpu_max: 10
hw.logicalcpu: 10
hw.logicalcpu_max: 10
hw.cputype: 16777228
hw.cpusubtype: 2
hw.cpu64bit_capable: 1
hw.cpufamily: 492472296
hw.cpusubfamily: 2
hw.cacheconfig: 10 1 6 0 0 0 0 0 0 0
hw.cachesize: 3408986112 65536 6291456 0 0 0 0 0 0 0
hw.pagesize: 16384
hw.pagesize32: 16384
hw.cachelinesize: 128
hw.l1icachesize: 131072
hw.l1dcachesize: 65536
hw.l2cachesize: 6291456
hw.tbfrequency: 24000000
hw.memsize_usable: 24883822592
hw.packages: 1
hw.osenvironment:
hw.ephemeral_storage: 0
hw.use_recovery_securityd: 0
hw.use_kernelmanagerd: 1
hw.serialdebugmode: 0
hw.nperflevels: 2
hw.targettype: J704
hw.jetsam_properties_product_type: J704
machdep.cpu.cores_per_package: 10
machdep.cpu.core_count: 10
machdep.cpu.logical_per_package: 10
machdep.cpu.thread_count: 10
machdep.cpu.brand_string: Apple M5
machdep.wake_abstime: 7300404675
machdep.time_since_reset: 55148567031
machdep.wake_conttime: 8034071509
machdep.deferred_ipi_timeout: 64000
machdep.virtual_address_size: 47
machdep.report_phy_read_delay: 0
machdep.report_phy_write_delay: 0
machdep.trace_phy_read_delay: 0
machdep.trace_phy_write_delay: 0
machdep.phy_read_delay_panic: 0
machdep.phy_write_delay_panic: 0
machdep.ptrauth_enabled: 1
machdep.ctrr_type: ctrrv3
machdep.user_idle_level: 0
```