### PR TITLE
Cache host() call

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Detection of CPU microarchitectures"""
 import collections
+import functools
 import os
 import platform
 import re
@@ -344,6 +345,7 @@ def compatible_microarchitectures(info: Microarchitecture) -> List[Microarchitec
     ]
 
 
+@functools.lru_cache(maxsize=None)
 def host() -> Microarchitecture:
     """Detects the host micro-architecture and returns it."""
     # Retrieve information on the host's cpu

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,9 @@ def reset_global_state(monkeypatch):
         )
 
     return _func
+
+
+@pytest.fixture(autouse=True)
+def clear_host_cache():
+    """Clears the cache for `archspec.cpu.host()` before each test."""
+    archspec.cpu.detect.host.cache_clear()


### PR DESCRIPTION
Detecting the current host machine is somewhat expensive. Here we cache the result, so that users don't have to pay for detection more than once.

On my Linux laptop:

**Before**
```console
python -m timeit -s "from archspec.cpu import host" "host()"
1000 loops, best of 5: 232 usec per loop
```

**After**
```console
python -m timeit -s "from archspec.cpu import host" "host()"
5000000 loops, best of 5: 40.1 nsec per loop
```