### PR TITLE
Fall back to newest known Apple M chip

### DIFF
--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -270,16 +270,14 @@ def sysctl_info() -> Microarchitecture:
 
     model = "unknown"
     model_str = sysctl("-n", "machdep.cpu.brand_string").lower()
-    if "m4" in model_str:
-        model = "m4"
-    elif "m3" in model_str:
-        model = "m3"
-    elif "m2" in model_str:
-        model = "m2"
-    elif "m1" in model_str:
-        model = "m1"
-    elif "apple" in model_str:
-        model = "m1"
+    # Example brand string: 'Apple M5', 'Apple M1 Pro'
+    match = re.search(r"apple\s+m(\d+)", model_str)
+    if match is not None:
+        # Found an M series: count down until we find a target we know about
+        for mnum in range(int(match.group(1)), 0, -1):
+            model = f"m{mnum}" 
+            if model in TARGETS:
+                break
 
     return partial_uarch(name=model, vendor="Apple")
 

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -314,21 +314,20 @@ def _sysctl_info_apple(data: Dict[str, str]) -> Microarchitecture:
     cpu_brand = data.get(MACHDEP_CPU_BRAND_STRING, "")
     model_str = cpu_brand.lower()
 
+    # Default to generic ARM model
+    model = "aarch64"
+
     # Example brand string: 'Apple M5', 'Apple M1 Pro'
     match = re.search(r"apple\s+m(\d+)", model_str)
     if match is not None:
-        # Found an M series: count down until we find a target we know about
+        # Found an M series: count down until we find a target in the jsonspec
         for mnum in range(int(match.group(1)), 0, -1):
             model = f"m{mnum}"
             if model in TARGETS:
                 break
-        else:
-            assert False, "No Apple M series in TARGETS"
     elif model_str == "apple processor":
         # Very old OS or processor: see json/tests/targets/darwin-bigsur-m1
         model = "m1"
-    else:
-        model = "unknown"
 
     return partial_uarch(name=model, vendor="Apple")
 

--- a/archspec/cpu/detect.py
+++ b/archspec/cpu/detect.py
@@ -319,11 +319,15 @@ def _sysctl_info_apple(data: Dict[str, str]) -> Microarchitecture:
     if match is not None:
         # Found an M series: count down until we find a target we know about
         for mnum in range(int(match.group(1)), 0, -1):
-            model = f"m{mnum}" 
+            model = f"m{mnum}"
             if model in TARGETS:
                 break
+        else:
+            assert False, "No Apple M series in TARGETS"
+    elif model_str == "apple processor":
+        # Very old OS or processor: see json/tests/targets/darwin-bigsur-m1
+        model = "m1"
     else:
-        # Not an Apple M series
         model = "unknown"
 
     return partial_uarch(name=model, vendor="Apple")

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -578,9 +578,9 @@ def test_tree_no_duplicate_nodes():
     Diamond structure used:
 
          diamond
-        /       \
+        /       \\
       left      right
-        \       /
+       \\       /
           root
     """
     root = Microarchitecture("root", parents=[], vendor="generic", features=set(), compilers={})

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -125,10 +125,6 @@ def targets_directory():
     ]
 )
 def expected_brand_string(request, monkeypatch):
-    """
-    Compare the brand string based on stored platform output in
-    :file:`archspec/json/test/targets/{filename}`.
-    """
     test_file, expected_result = request.param
     filename = os.path.join(targets_directory(), test_file)
     if "darwin" in test_file:
@@ -553,14 +549,15 @@ def test_brand_string(expected_brand_string):
         ("Apple M4", "m4"),
         # NOTE: this must be updated when jsonschema adds M5 and newer
         ("Apple M2000", "m4"),
-    ]
+    ],
 )
 def test_sysctl_info_apple(brand_string, expected_name):
-    uarch = archspec.cpu.detect._sysctl_info_apple({
-        archspec.cpu.detect.MACHDEP_CPU_BRAND_STRING: brand_string
-    })
+    uarch = archspec.cpu.detect._sysctl_info_apple(
+        {archspec.cpu.detect.MACHDEP_CPU_BRAND_STRING: brand_string}
+    )
     assert uarch.name == expected_name
     assert uarch.vendor == "Apple"
+
 
 @pytest.mark.parametrize(
     "version_str",

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -560,6 +560,7 @@ def test_sysctl_info_apple(brand_string, expected_name):
         archspec.cpu.detect.MACHDEP_CPU_BRAND_STRING: brand_string
     })
     assert uarch.name == expected_name
+    assert uarch.vendor == "Apple"
 
 @pytest.mark.parametrize(
     "version_str",

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -125,6 +125,10 @@ def targets_directory():
     ]
 )
 def expected_brand_string(request, monkeypatch):
+    """
+    Compare the brand string based on stored platform output in
+    :file:`archspec/json/test/targets/{filename}`.
+    """
     test_file, expected_result = request.param
     filename = os.path.join(targets_directory(), test_file)
     if "darwin" in test_file:
@@ -539,6 +543,23 @@ def test_only_one_extension_file(extension_file, monkeypatch, reset_global_state
 def test_brand_string(expected_brand_string):
     assert archspec.cpu.detect.brand_string() == expected_brand_string
 
+
+@pytest.mark.parametrize(
+    "brand_string,expected_name",
+    [
+        ("Apple processor", "m1"),
+        ("Apple M1 Pro", "m1"),
+        ("Apple M2 Max", "m2"),
+        ("Apple M4", "m4"),
+        # NOTE: this must be updated when jsonschema adds M5 and newer
+        ("Apple M2000", "m4"),
+    ]
+)
+def test_sysctl_info_apple(brand_string, expected_name):
+    uarch = archspec.cpu.detect._sysctl_info_apple({
+        archspec.cpu.detect.MACHDEP_CPU_BRAND_STRING: brand_string
+    })
+    assert uarch.name == expected_name
 
 @pytest.mark.parametrize(
     "version_str",

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -600,9 +600,9 @@ def test_tree_no_duplicate_nodes():
     Diamond structure used:
 
          diamond
-        /       \\
+        /       \
       left      right
-       \\       /
+        \       /
           root
     """
     root = Microarchitecture("root", parents=[], vendor="generic", features=set(), compilers={})


### PR DESCRIPTION
This is a long-term patch for identifying M series Apple chips (closing https://github.com/archspec/archspec/pull/216 ). Currently:
- A hard-coded list of M series must be kept in sync with archspec-json
- A newer processor than that hard-coded list falls back to the oldest M1 chip, not the latest known chip.

This PR changes it so that *no* syncing is needed (since the target list is checked via python), and the fallback is to the latest known apple chip.