### PR TITLE
Implement GPU detection and CLI functionality

### DIFF
--- a/archspec/cli.py
+++ b/archspec/cli.py
@@ -11,6 +11,7 @@ import typing
 
 from . import __version__ as archspec_version
 from .cpu import host, why_not
+from .gpu import host as gpu_host
 
 
 def _make_parser() -> argparse.ArgumentParser:
@@ -48,6 +49,20 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     cpu_command.set_defaults(run=cpu)
 
+    gpu_command = subcommands.add_parser(
+        "gpu",
+        help="archspec command line interface for GPU",
+        description="archspec command line interface for GPU",
+    )
+    gpu_command.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        dest="verbose",
+        help="Display detailed GPU information and exit.",
+    )
+    gpu_command.set_defaults(run=gpu)
+
     return parser
 
 
@@ -61,6 +76,32 @@ def cpu(args) -> int:
     except FileNotFoundError as exc:
         print(exc)
         return 1
+    return 0
+
+
+def gpu(args) -> int:
+    """Run the `archspec gpu` subcommand."""
+    try:
+        gpus = gpu_host()
+    except Exception as exc:  # pylint: disable=broad-except
+        print(exc)
+        return 1
+
+    if not gpus:
+        print("No GPUs detected.")
+        return 0
+
+    num_gpus = len(gpus)
+    print(f"Detected {num_gpus} GPU(s).\n")
+    for i in range(num_gpus):
+        print(f"GPU {i}:")
+        if args.verbose:
+            print(gpus[i].detailed_string())
+        else:
+            print(gpus[i])
+        if i < (num_gpus - 1):
+            print()
+
     return 0
 
 

--- a/archspec/gpu/__init__.py
+++ b/archspec/gpu/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""The "gpu" package permits detection and querying of GPU microarchitectures."""
+from .detect import host
+
+__all__ = [
+    "host",
+]

--- a/archspec/gpu/__init__.py
+++ b/archspec/gpu/__init__.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """The "gpu" package permits detection and querying of GPU microarchitectures."""
 from .detect import host
+from .gpu_microarch import GPUMicroarch
 
 __all__ = [
+    "GPUMicroarch",
     "host",
 ]

--- a/archspec/gpu/__init__.py
+++ b/archspec/gpu/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
 # Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/archspec/gpu/amd.py
+++ b/archspec/gpu/amd.py
@@ -9,8 +9,8 @@ import subprocess
 import warnings
 from typing import List
 
-from archspec.gpu.generic import GPU_VENDORS
-from archspec.gpu.gpu_microarch import GPUMicroarch
+from .generic import GPU_VENDORS
+from .gpu_microarch import GPUMicroarch
 
 
 def smi_info() -> List[GPUMicroarch]:

--- a/archspec/gpu/amd.py
+++ b/archspec/gpu/amd.py
@@ -9,7 +9,7 @@ import subprocess
 import warnings
 from typing import List
 
-from .generic import GPU_VENDORS
+from . import schema
 from .gpu_microarch import GPUMicroarch
 
 
@@ -43,7 +43,9 @@ def smi_info() -> List[GPUMicroarch]:
 
     # AMD's PCI vendor code is not reported by rocm-smi, so derive it from the
     # known vendor mapping the same way the ``vendor`` field is hardcoded.
-    vendor_pci_code = next(code for code, name in GPU_VENDORS.items() if name == "amd")
+    vendor_pci_code = next(
+        code for code, name in schema.DETECTION_JSON["vendors"].items() if name == "amd"
+    )
 
     # The driver version is reported once for the whole system rather than
     # per-card, under a top-level "system" entry.

--- a/archspec/gpu/amd.py
+++ b/archspec/gpu/amd.py
@@ -1,0 +1,75 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Detection of AMD GPUs through the rocm-smi toolchain."""
+
+import json
+import subprocess
+import warnings
+from typing import List
+
+from archspec.gpu.generic import GPU_VENDORS
+from archspec.gpu.gpu_microarch import GPUMicroarch
+
+
+def smi_info() -> List[GPUMicroarch]:
+    """Retrieve info for all AMD GPUs using rocm-smi."""
+
+    try:
+        result = subprocess.run(
+            [
+                "rocm-smi",
+                "--showproductname",
+                "--showdriverversion",
+                "--showid",
+                "--json",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        warnings.warn("rocm-smi is not installed; skipping AMD GPU detection")
+        return []
+    except subprocess.CalledProcessError:
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except ValueError:
+        return []
+
+    # AMD's PCI vendor code is not reported by rocm-smi, so derive it from the
+    # known vendor mapping the same way the ``vendor`` field is hardcoded.
+    vendor_pci_code = next(code for code, name in GPU_VENDORS.items() if name == "amd")
+
+    # The driver version is reported once for the whole system rather than
+    # per-card, under a top-level "system" entry.
+    system_info = data.get("system", {})
+    driver_version = system_info.get("Driver version", "")
+
+    gpus: List[GPUMicroarch] = []
+    for key, info in data.items():
+        if not key.startswith("card"):
+            continue
+
+        # Key names vary across rocm-smi versions, so fall back across the
+        # known aliases for the marketing name and the PCI device ID.
+        brand_string = info.get("Card Series") or info.get("Market Name") or ""
+        component_pci_code = info.get("Device ID") or info.get("GPU ID") or ""
+        gfx_version = info.get("GFX Version") or ""
+
+        gpus.append(
+            GPUMicroarch(
+                name=gfx_version,
+                vendor="amd",
+                brand_string=brand_string,
+                driver_version=driver_version,
+                component_pci_code=component_pci_code.lower(),
+                vendor_pci_code=vendor_pci_code,
+                gfx_target=gfx_version,
+            )
+        )
+    return gpus

--- a/archspec/gpu/detect.py
+++ b/archspec/gpu/detect.py
@@ -6,41 +6,17 @@
 
 import collections
 import functools
-import json
-import os
 import platform
 import shutil
-import subprocess
 import warnings
 from typing import Callable, Dict, List, Tuple
 
+from archspec.gpu import amd, generic, nvidia
 from archspec.gpu.gpu_microarch import GPUMicroarch
-
-# --- Constants and Detection Variables ---
-
-#: PCI class codes for GPU devices
-#: https://admin.pci-ids.ucw.cz/read/PD/03
-GPU_PCI_CLASSES = ("0x030000", "0x030200", "0x120000")
-
-#: Mapping from PCI vendor IDs to vendor names
-#: https://devicehunt.com/view/type/pci/vendor/10DE -- NVIDIA
-#: https://devicehunt.com/view/type/pci/vendor/1002 -- AMD
-#: https://devicehunt.com/view/type/pci/vendor/8086 -- INTEL
-GPU_VENDORS = {
-    "0x10de": "nvidia",
-    "0x1002": "amd",
-    "0x8086": "intel",
-}
-
-#: Path to the sysfs PCI devices directory
-SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
 
 #: Mapping from operating systems to chain of commands
 #: to obtain a list of raw info on the current gpus
 INFO_FACTORY: Dict[str, List[Callable]] = collections.defaultdict(list)
-
-
-# --- Decorator definitions ---
 
 
 def detection(operating_system: str):
@@ -57,257 +33,11 @@ def detection(operating_system: str):
     return decorator
 
 
-# --- sysfs detection logic ---
-
-
-def _read_sysfs_file(path: str) -> str:
-    """Read and strip the contents of a sysfs file."""
-    with open(path) as f:  # pylint: disable=unspecified-encoding
-        return f.read().strip()
-
-
-def _parse_nvidia_pci_device_id(combined_id: str) -> Tuple[str, str]:
-    """Parse a combined PCI device ID into (device, vendor) codes.
-
-    Args:
-        combined_id: 10-character hex string from nvidia-smi ``pci.device_id``
-            (e.g. ``0x2C0210DE``).
-
-    Returns:
-        A tuple of ``(component_pci_code, vendor_pci_code)`` in lowercase
-        (e.g. ``("0x2c02", "0x10de")``).
-
-    Raises:
-        ValueError: if *combined_id* is not a valid 10-character hex string
-            with a ``0x`` prefix.
-    """
-    if len(combined_id) != 10 or combined_id[:2] != "0x":
-        raise ValueError(
-            "invalid PCI device ID: expected 10-character '0x'-prefixed hex"
-            f" string, got {combined_id!r}"
-        )
-
-    hex_digits = combined_id[2:]
-    return (f"0x{hex_digits[:4]}".lower(), f"0x{hex_digits[4:]}".lower())
-
-
-def _scan_sysfs_pci_for_gpus() -> List[GPUMicroarch]:
-    """Enumerate GPUs by scanning sysfs PCI devices.
-
-    Iterates over ``/sys/bus/pci/devices/`` and yields one entry per device whose
-    PCI class indicates a GPU. Each entry carries only the identity available
-    without a vendor tool: the vendor name and the PCI vendor and device codes.
-
-    Returns:
-        A list of GPUMicroarch, one per GPU-class PCI device on the system.
-    """
-    gpus: List[GPUMicroarch] = []
-
-    if not os.path.isdir(SYSFS_PCI_DEVICES):
-        return gpus
-
-    for entry in os.listdir(SYSFS_PCI_DEVICES):
-        device_dir = os.path.join(SYSFS_PCI_DEVICES, entry)
-        if not os.path.isdir(device_dir):
-            continue
-
-        try:
-            class_path = os.path.join(device_dir, "class")
-            if not os.path.exists(class_path):
-                continue
-            if _read_sysfs_file(class_path) not in GPU_PCI_CLASSES:
-                continue
-
-            vendor_id = _read_sysfs_file(os.path.join(device_dir, "vendor"))
-            vendor_name = GPU_VENDORS.get(vendor_id)
-            if vendor_name is None:
-                continue
-
-            gpus.append(
-                GPUMicroarch(
-                    vendor=vendor_name,
-                    vendor_pci_code=vendor_id,
-                    component_pci_code=_read_sysfs_file(os.path.join(device_dir, "device")),
-                )
-            )
-        except OSError as exc:
-            warnings.warn(f"skipping PCI device {entry!r}: {exc}")
-
-    return gpus
-
-
-# --- nvidia-smi toolchain logic ---
-
-
-#: Fields queried from nvidia-smi, in output-column order. ``compute_cap`` is
-#: only recognized on newer drivers (~R495+); on older drivers it is dropped
-#: (see ``_nvidia_smi_info``), so it is kept last to keep the leading columns
-#: at stable indices regardless of whether it is present.
-_NVIDIA_SMI_BASE_FIELDS = ["gpu_name", "driver_version", "pci.device_id"]
-
-
-def _run_nvidia_smi(fields: List[str]) -> subprocess.CompletedProcess:
-    """Run nvidia-smi querying the given GPU fields, in CSV format."""
-    return subprocess.run(
-        [
-            "nvidia-smi",
-            f"--query-gpu={','.join(fields)}",
-            "--format=csv,noheader",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-
-
-def _nvidia_smi_info() -> List[GPUMicroarch]:
-    """Retrieve info for all NVIDIA GPUs using nvidia-smi."""
-
-    # Try query with compute_cap first, then fall back without it.
-    fields = _NVIDIA_SMI_BASE_FIELDS + ["compute_cap"]
-    try:
-        result = _run_nvidia_smi(fields)
-    except FileNotFoundError:
-        warnings.warn("nvidia-smi is not installed; skipping NVIDIA GPU detection")
-        return []
-    except subprocess.CalledProcessError:
-        # An unrecognized query field (compute_cap on older drivers, ~pre-R495)
-        # fails the whole query, so retry with just the base fields rather than
-        # losing detection entirely.
-        fields = _NVIDIA_SMI_BASE_FIELDS
-        try:
-            result = _run_nvidia_smi(fields)
-        except subprocess.CalledProcessError:
-            return []
-
-    gpus: List[GPUMicroarch] = []
-    for line in result.stdout.strip().splitlines():
-        parts = [p.strip() for p in line.split(",")]
-        # parts align positionally with `fields`:
-        # [brand_string, driver_version, combined vendor+device pci code(, compute_cap)]
-        if len(parts) < len(_NVIDIA_SMI_BASE_FIELDS):
-            continue
-
-        # Skip this gpu if id parsing is malformed
-        try:
-            pci_codes = _parse_nvidia_pci_device_id(parts[2])
-        except ValueError as e:
-            warnings.warn(f"skipping NVIDIA GPU: {e}")
-            continue
-
-        compute_capability = (
-            _compute_capability_to_compiler_flag(parts[3]) if len(parts) > 3 else ""
-        )
-        gpus.append(
-            GPUMicroarch(
-                name=compute_capability,
-                vendor="nvidia",
-                brand_string=parts[0],
-                driver_version=parts[1],
-                component_pci_code=pci_codes[0],
-                vendor_pci_code=pci_codes[1],
-                compute_capability=compute_capability,
-            )
-        )
-    return gpus
-
-
-def _compute_capability_to_compiler_flag(name: str) -> str:
-    """Transform decimal format compute capability to format expected by compiler flags.
-
-    e.g. 9.0 -> sm_90
-    """
-    # validation
-    if not name:
-        return ""
-
-    if not name[0].isdigit() or "." not in name:
-        return ""
-
-    # parsing
-    parsed_name = name.replace(".", "")
-    parsed_name = f"sm_{parsed_name}"
-
-    return parsed_name
-
-
-# --- rocm-smi toolchain logic ---
-
-
-def _rocm_smi_info() -> List[GPUMicroarch]:
-    """Retrieve info for all AMD GPUs using rocm-smi."""
-
-    try:
-        result = subprocess.run(
-            [
-                "rocm-smi",
-                "--showproductname",
-                "--showdriverversion",
-                "--showid",
-                "--json",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-            check=True,
-        )
-    except FileNotFoundError:
-        warnings.warn("rocm-smi is not installed; skipping AMD GPU detection")
-        return []
-    except subprocess.CalledProcessError:
-        return []
-
-    try:
-        data = json.loads(result.stdout)
-    except ValueError:
-        return []
-
-    # AMD's PCI vendor code is not reported by rocm-smi, so derive it from the
-    # known vendor mapping the same way the ``vendor`` field is hardcoded.
-    vendor_pci_code = next(code for code, name in GPU_VENDORS.items() if name == "amd")
-
-    # The driver version is reported once for the whole system rather than
-    # per-card, under a top-level "system" entry.
-    system_info = data.get("system", {})
-    driver_version = system_info.get("Driver version", "")
-
-    gpus: List[GPUMicroarch] = []
-    for key, info in data.items():
-        if not key.startswith("card"):
-            continue
-
-        # Key names vary across rocm-smi versions, so fall back across the
-        # known aliases for the marketing name and the PCI device ID.
-        brand_string = info.get("Card Series") or info.get("Market Name") or ""
-        component_pci_code = info.get("Device ID") or info.get("GPU ID") or ""
-        gfx_version = info.get("GFX Version") or ""
-
-        gpus.append(
-            GPUMicroarch(
-                name=gfx_version,
-                vendor="amd",
-                brand_string=brand_string,
-                driver_version=driver_version,
-                component_pci_code=component_pci_code.lower(),
-                vendor_pci_code=vendor_pci_code,
-                gfx_target=gfx_version,
-            )
-        )
-    return gpus
-
-
-# --- general smi logic ---
-
-
 #: Vendor SMI tools used to enrich detection: (executable, info function).
 _SMI_SOURCES: List[Tuple[str, Callable[[], List[GPUMicroarch]]]] = [
-    ("nvidia-smi", _nvidia_smi_info),
-    ("rocm-smi", _rocm_smi_info),
+    ("nvidia-smi", nvidia.smi_info),
+    ("rocm-smi", amd.smi_info),
 ]
-
-
-# --- final resolution logic ---
 
 
 @detection(operating_system="Linux")
@@ -321,7 +51,7 @@ def _detect_gpus_linux() -> List[GPUMicroarch]:
 
     described = {(gpu.vendor_pci_code, gpu.component_pci_code) for gpu in results}
 
-    for gpu in _scan_sysfs_pci_for_gpus():
+    for gpu in generic.scan_sysfs_pci_for_gpus():
         if (gpu.vendor_pci_code, gpu.component_pci_code) not in described:
             results.append(gpu)
 

--- a/archspec/gpu/detect.py
+++ b/archspec/gpu/detect.py
@@ -11,8 +11,8 @@ import shutil
 import warnings
 from typing import Callable, Dict, List, Tuple
 
-from archspec.gpu import amd, generic, nvidia
-from archspec.gpu.gpu_microarch import GPUMicroarch
+from . import amd, generic, nvidia
+from .gpu_microarch import GPUMicroarch
 
 #: Mapping from operating systems to chain of commands
 #: to obtain a list of raw info on the current gpus

--- a/archspec/gpu/detect.py
+++ b/archspec/gpu/detect.py
@@ -1,0 +1,347 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Detection of GPU microarchitectures"""
+
+import collections
+import functools
+import json
+import os
+import platform
+import shutil
+import subprocess
+import warnings
+from typing import Callable, Dict, List, Tuple
+
+from archspec.gpu.gpu_microarch import GPUMicroarch
+
+# --- Constants and Detection Variables ---
+
+#: PCI class codes for GPU devices
+#: https://admin.pci-ids.ucw.cz/read/PD/03
+GPU_PCI_CLASSES = ("0x030000", "0x030200", "0x120000")
+
+#: Mapping from PCI vendor IDs to vendor names
+#: https://devicehunt.com/view/type/pci/vendor/10DE -- NVIDIA
+#: https://devicehunt.com/view/type/pci/vendor/1002 -- AMD
+#: https://devicehunt.com/view/type/pci/vendor/8086 -- INTEL
+GPU_VENDORS = {
+    "0x10de": "nvidia",
+    "0x1002": "amd",
+    "0x8086": "intel",
+}
+
+#: Path to the sysfs PCI devices directory
+SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
+
+#: Mapping from operating systems to chain of commands
+#: to obtain a list of raw info on the current gpus
+INFO_FACTORY: Dict[str, List[Callable]] = collections.defaultdict(list)
+
+
+# --- Decorator definitions ---
+
+
+def detection(operating_system: str):
+    """Decorator to mark functions that are meant to return raw information on detected GPUs.
+
+    Args:
+        operating_system: operating system where this function can be used.
+    """
+
+    def decorator(factory):
+        INFO_FACTORY[operating_system].append(factory)
+        return factory
+
+    return decorator
+
+
+# --- sysfs detection logic ---
+
+
+def _read_sysfs_file(path: str) -> str:
+    """Read and strip the contents of a sysfs file."""
+    with open(path) as f:  # pylint: disable=unspecified-encoding
+        return f.read().strip()
+
+
+def _parse_nvidia_pci_device_id(combined_id: str) -> Tuple[str, str]:
+    """Parse a combined PCI device ID into (device, vendor) codes.
+
+    Args:
+        combined_id: 10-character hex string from nvidia-smi ``pci.device_id``
+            (e.g. ``0x2C0210DE``).
+
+    Returns:
+        A tuple of ``(component_pci_code, vendor_pci_code)`` in lowercase
+        (e.g. ``("0x2c02", "0x10de")``).
+
+    Raises:
+        ValueError: if *combined_id* is not a valid 10-character hex string
+            with a ``0x`` prefix.
+    """
+    if len(combined_id) != 10 or combined_id[:2] != "0x":
+        raise ValueError(
+            "invalid PCI device ID: expected 10-character '0x'-prefixed hex"
+            f" string, got {combined_id!r}"
+        )
+
+    hex_digits = combined_id[2:]
+    return (f"0x{hex_digits[:4]}".lower(), f"0x{hex_digits[4:]}".lower())
+
+
+def _scan_sysfs_pci_for_gpus() -> List[GPUMicroarch]:
+    """Enumerate GPUs by scanning sysfs PCI devices.
+
+    Iterates over ``/sys/bus/pci/devices/`` and yields one entry per device whose
+    PCI class indicates a GPU. Each entry carries only the identity available
+    without a vendor tool: the vendor name and the PCI vendor and device codes.
+
+    Returns:
+        A list of GPUMicroarch, one per GPU-class PCI device on the system.
+    """
+    gpus: List[GPUMicroarch] = []
+
+    if not os.path.isdir(SYSFS_PCI_DEVICES):
+        return gpus
+
+    for entry in os.listdir(SYSFS_PCI_DEVICES):
+        device_dir = os.path.join(SYSFS_PCI_DEVICES, entry)
+        if not os.path.isdir(device_dir):
+            continue
+
+        try:
+            class_path = os.path.join(device_dir, "class")
+            if not os.path.exists(class_path):
+                continue
+            if _read_sysfs_file(class_path) not in GPU_PCI_CLASSES:
+                continue
+
+            vendor_id = _read_sysfs_file(os.path.join(device_dir, "vendor"))
+            vendor_name = GPU_VENDORS.get(vendor_id)
+            if vendor_name is None:
+                continue
+
+            gpus.append(
+                GPUMicroarch(
+                    vendor=vendor_name,
+                    vendor_pci_code=vendor_id,
+                    component_pci_code=_read_sysfs_file(os.path.join(device_dir, "device")),
+                )
+            )
+        except OSError as exc:
+            warnings.warn(f"skipping PCI device {entry!r}: {exc}")
+
+    return gpus
+
+
+# --- nvidia-smi toolchain logic ---
+
+
+#: Fields queried from nvidia-smi, in output-column order. ``compute_cap`` is
+#: only recognized on newer drivers (~R495+); on older drivers it is dropped
+#: (see ``_nvidia_smi_info``), so it is kept last to keep the leading columns
+#: at stable indices regardless of whether it is present.
+_NVIDIA_SMI_BASE_FIELDS = ["gpu_name", "driver_version", "pci.device_id"]
+
+
+def _run_nvidia_smi(fields: List[str]) -> subprocess.CompletedProcess:
+    """Run nvidia-smi querying the given GPU fields, in CSV format."""
+    return subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-gpu={','.join(fields)}",
+            "--format=csv,noheader",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+
+
+def _nvidia_smi_info() -> List[GPUMicroarch]:
+    """Retrieve info for all NVIDIA GPUs using nvidia-smi."""
+
+    # Try query with compute_cap first, then fall back without it.
+    fields = _NVIDIA_SMI_BASE_FIELDS + ["compute_cap"]
+    try:
+        result = _run_nvidia_smi(fields)
+    except FileNotFoundError:
+        warnings.warn("nvidia-smi is not installed; skipping NVIDIA GPU detection")
+        return []
+    except subprocess.CalledProcessError:
+        # An unrecognized query field (compute_cap on older drivers, ~pre-R495)
+        # fails the whole query, so retry with just the base fields rather than
+        # losing detection entirely.
+        fields = _NVIDIA_SMI_BASE_FIELDS
+        try:
+            result = _run_nvidia_smi(fields)
+        except subprocess.CalledProcessError:
+            return []
+
+    gpus: List[GPUMicroarch] = []
+    for line in result.stdout.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        # parts align positionally with `fields`:
+        # [brand_string, driver_version, combined vendor+device pci code(, compute_cap)]
+        if len(parts) < len(_NVIDIA_SMI_BASE_FIELDS):
+            continue
+
+        # Skip this gpu if id parsing is malformed
+        try:
+            pci_codes = _parse_nvidia_pci_device_id(parts[2])
+        except ValueError as e:
+            warnings.warn(f"skipping NVIDIA GPU: {e}")
+            continue
+
+        compute_capability = (
+            _compute_capability_to_compiler_flag(parts[3]) if len(parts) > 3 else ""
+        )
+        gpus.append(
+            GPUMicroarch(
+                name=compute_capability,
+                vendor="nvidia",
+                brand_string=parts[0],
+                driver_version=parts[1],
+                component_pci_code=pci_codes[0],
+                vendor_pci_code=pci_codes[1],
+                compute_capability=compute_capability,
+            )
+        )
+    return gpus
+
+
+def _compute_capability_to_compiler_flag(name: str) -> str:
+    """Transform decimal format compute capability to format expected by compiler flags.
+
+    e.g. 9.0 -> sm_90
+    """
+    # validation
+    if not name:
+        return ""
+
+    if not name[0].isdigit() or "." not in name:
+        return ""
+
+    # parsing
+    parsed_name = name.replace(".", "")
+    parsed_name = f"sm_{parsed_name}"
+
+    return parsed_name
+
+
+# --- rocm-smi toolchain logic ---
+
+
+def _rocm_smi_info() -> List[GPUMicroarch]:
+    """Retrieve info for all AMD GPUs using rocm-smi."""
+
+    try:
+        result = subprocess.run(
+            [
+                "rocm-smi",
+                "--showproductname",
+                "--showdriverversion",
+                "--showid",
+                "--json",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        warnings.warn("rocm-smi is not installed; skipping AMD GPU detection")
+        return []
+    except subprocess.CalledProcessError:
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except ValueError:
+        return []
+
+    # AMD's PCI vendor code is not reported by rocm-smi, so derive it from the
+    # known vendor mapping the same way the ``vendor`` field is hardcoded.
+    vendor_pci_code = next(code for code, name in GPU_VENDORS.items() if name == "amd")
+
+    # The driver version is reported once for the whole system rather than
+    # per-card, under a top-level "system" entry.
+    system_info = data.get("system", {})
+    driver_version = system_info.get("Driver version", "")
+
+    gpus: List[GPUMicroarch] = []
+    for key, info in data.items():
+        if not key.startswith("card"):
+            continue
+
+        # Key names vary across rocm-smi versions, so fall back across the
+        # known aliases for the marketing name and the PCI device ID.
+        brand_string = info.get("Card Series") or info.get("Market Name") or ""
+        component_pci_code = info.get("Device ID") or info.get("GPU ID") or ""
+        gfx_version = info.get("GFX Version") or ""
+
+        gpus.append(
+            GPUMicroarch(
+                name=gfx_version,
+                vendor="amd",
+                brand_string=brand_string,
+                driver_version=driver_version,
+                component_pci_code=component_pci_code.lower(),
+                vendor_pci_code=vendor_pci_code,
+                gfx_target=gfx_version,
+            )
+        )
+    return gpus
+
+
+# --- general smi logic ---
+
+
+#: Vendor SMI tools used to enrich detection: (executable, info function).
+_SMI_SOURCES: List[Tuple[str, Callable[[], List[GPUMicroarch]]]] = [
+    ("nvidia-smi", _nvidia_smi_info),
+    ("rocm-smi", _rocm_smi_info),
+]
+
+
+# --- final resolution logic ---
+
+
+@detection(operating_system="Linux")
+def _detect_gpus_linux() -> List[GPUMicroarch]:
+    """Enumerate all GPUs present on Linux: vendor SMI tools plus a sysfs PCI scan fallback."""
+    results: List[GPUMicroarch] = []
+
+    for executable, info_fn in _SMI_SOURCES:
+        if shutil.which(executable) is not None:
+            results.extend(info_fn())
+
+    described = {(gpu.vendor_pci_code, gpu.component_pci_code) for gpu in results}
+
+    for gpu in _scan_sysfs_pci_for_gpus():
+        if (gpu.vendor_pci_code, gpu.component_pci_code) not in described:
+            results.append(gpu)
+
+    return results
+
+
+@functools.lru_cache(maxsize=None)
+def host() -> List[GPUMicroarch]:
+    """Detects the GPUs on the host system and returns information about them.
+
+    Returns:
+        A list of GPUMicroarch objects, one per detected GPU.
+    """
+    results: List[GPUMicroarch] = []
+
+    for factory in INFO_FACTORY[platform.system()]:
+        try:
+            results = factory()
+            break
+        except Exception as e:  # pylint: disable=broad-except
+            warnings.warn(str(e))
+
+    return results

--- a/archspec/gpu/generic.py
+++ b/archspec/gpu/generic.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from typing import List
 
-from archspec.gpu.gpu_microarch import GPUMicroarch
+from .gpu_microarch import GPUMicroarch
 
 #: PCI class codes for GPU devices
 #: https://admin.pci-ids.ucw.cz/read/PD/03

--- a/archspec/gpu/generic.py
+++ b/archspec/gpu/generic.py
@@ -1,0 +1,79 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Vendor-agnostic GPU enumeration based on sysfs PCI scanning."""
+
+import os
+import warnings
+from typing import List
+
+from archspec.gpu.gpu_microarch import GPUMicroarch
+
+#: PCI class codes for GPU devices
+#: https://admin.pci-ids.ucw.cz/read/PD/03
+GPU_PCI_CLASSES = ("0x030000", "0x030200", "0x120000")
+
+#: Mapping from PCI vendor IDs to vendor names
+#: https://devicehunt.com/view/type/pci/vendor/10DE -- NVIDIA
+#: https://devicehunt.com/view/type/pci/vendor/1002 -- AMD
+#: https://devicehunt.com/view/type/pci/vendor/8086 -- INTEL
+GPU_VENDORS = {
+    "0x10de": "nvidia",
+    "0x1002": "amd",
+    "0x8086": "intel",
+}
+
+#: Path to the sysfs PCI devices directory
+SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
+
+
+def _read_sysfs_file(path: str) -> str:
+    """Read and strip the contents of a sysfs file."""
+    with open(path) as f:  # pylint: disable=unspecified-encoding
+        return f.read().strip()
+
+
+def scan_sysfs_pci_for_gpus() -> List[GPUMicroarch]:
+    """Enumerate GPUs by scanning sysfs PCI devices.
+
+    Iterates over ``/sys/bus/pci/devices/`` and yields one entry per device whose
+    PCI class indicates a GPU. Each entry carries only the identity available
+    without a vendor tool: the vendor name and the PCI vendor and device codes.
+
+    Returns:
+        A list of GPUMicroarch, one per GPU-class PCI device on the system.
+    """
+    gpus: List[GPUMicroarch] = []
+
+    if not os.path.isdir(SYSFS_PCI_DEVICES):
+        return gpus
+
+    for entry in os.listdir(SYSFS_PCI_DEVICES):
+        device_dir = os.path.join(SYSFS_PCI_DEVICES, entry)
+        if not os.path.isdir(device_dir):
+            continue
+
+        try:
+            class_path = os.path.join(device_dir, "class")
+            if not os.path.exists(class_path):
+                continue
+            if _read_sysfs_file(class_path) not in GPU_PCI_CLASSES:
+                continue
+
+            vendor_id = _read_sysfs_file(os.path.join(device_dir, "vendor"))
+            vendor_name = GPU_VENDORS.get(vendor_id)
+            if vendor_name is None:
+                continue
+
+            gpus.append(
+                GPUMicroarch(
+                    vendor=vendor_name,
+                    vendor_pci_code=vendor_id,
+                    component_pci_code=_read_sysfs_file(os.path.join(device_dir, "device")),
+                )
+            )
+        except OSError as exc:
+            warnings.warn(f"skipping PCI device {entry!r}: {exc}")
+
+    return gpus

--- a/archspec/gpu/generic.py
+++ b/archspec/gpu/generic.py
@@ -8,21 +8,8 @@ import os
 import warnings
 from typing import List
 
+from . import schema
 from .gpu_microarch import GPUMicroarch
-
-#: PCI class codes for GPU devices
-#: https://admin.pci-ids.ucw.cz/read/PD/03
-GPU_PCI_CLASSES = ("0x030000", "0x030200", "0x120000")
-
-#: Mapping from PCI vendor IDs to vendor names
-#: https://devicehunt.com/view/type/pci/vendor/10DE -- NVIDIA
-#: https://devicehunt.com/view/type/pci/vendor/1002 -- AMD
-#: https://devicehunt.com/view/type/pci/vendor/8086 -- INTEL
-GPU_VENDORS = {
-    "0x10de": "nvidia",
-    "0x1002": "amd",
-    "0x8086": "intel",
-}
 
 #: Path to the sysfs PCI devices directory
 SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
@@ -49,6 +36,9 @@ def scan_sysfs_pci_for_gpus() -> List[GPUMicroarch]:
     if not os.path.isdir(SYSFS_PCI_DEVICES):
         return gpus
 
+    gpu_pci_classes = schema.DETECTION_JSON["pci_classes"]
+    gpu_vendors = schema.DETECTION_JSON["vendors"]
+
     for entry in os.listdir(SYSFS_PCI_DEVICES):
         device_dir = os.path.join(SYSFS_PCI_DEVICES, entry)
         if not os.path.isdir(device_dir):
@@ -58,11 +48,11 @@ def scan_sysfs_pci_for_gpus() -> List[GPUMicroarch]:
             class_path = os.path.join(device_dir, "class")
             if not os.path.exists(class_path):
                 continue
-            if _read_sysfs_file(class_path) not in GPU_PCI_CLASSES:
+            if _read_sysfs_file(class_path) not in gpu_pci_classes:
                 continue
 
             vendor_id = _read_sysfs_file(os.path.join(device_dir, "vendor"))
-            vendor_name = GPU_VENDORS.get(vendor_id)
+            vendor_name = gpu_vendors.get(vendor_id)
             if vendor_name is None:
                 continue
 

--- a/archspec/gpu/gpu_microarch.py
+++ b/archspec/gpu/gpu_microarch.py
@@ -1,0 +1,69 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Defines the GPUMicroarch class, describing a detected GPU microarchitecture."""
+
+
+class GPUMicroarch:
+    """Specific GPU Microarchitecture"""
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-instance-attributes
+
+    def __init__(
+        self,
+        name: str = "",
+        brand_string: str = "",
+        vendor: str = "",
+        driver_version: str = "",
+        vendor_pci_code: str = "",
+        component_pci_code: str = "",
+        # Only relevant for NVIDIA
+        compute_capability: str = "",
+        # Only relevant for AMD
+        gfx_target: str = "",
+    ):
+        """
+        Args:
+            name: compatability identifier name (e.g. ``sm_90`` for NVIDIA, ``gfx902`` for AMD)
+            brand_string: marketing name of specific device (e.g. ``NVIDIA GeForce RTX 5080``)
+            vendor: name of chip manufacturer (e.g. ``nvidia``)
+            driver_version: version number of currently installed driver (e.g. ``595.58.03``)
+            vendor_pci_code: 4-digit hex string used to identify vendor (e.g. ``0x8086`` for intel)
+            component_pci_code: 4-digit hex string used to identify GPU (e.g. ``0x2c02``)
+            compute_capability: NVIDIA-specific compatability identifier (e.g. ``sm_90``)
+            gfx_target: AMD-specific compatability identifier (e.g. ``gfx902``)
+        """
+        self.name = name
+        self.brand_string = brand_string
+        self.vendor = vendor
+        self.driver_version = driver_version
+        self.vendor_pci_code = vendor_pci_code
+        self.component_pci_code = component_pci_code
+        # Only relevant for NVIDIA
+        self.compute_capability = compute_capability
+        # Only relevant for AMD
+        self.gfx_target = gfx_target
+
+    def __repr__(self) -> str:
+        fields = ", ".join(
+            f"{field}={value!r}" for field, value in vars(self).items() if value != ""
+        )
+        return f"{self.__class__.__name__}({fields})"
+
+    def __str__(self) -> str:
+        if self.name and self.vendor:
+            return f"{self.name} ({self.vendor})"
+        if self.vendor and self.component_pci_code:
+            return f"unresolved {self.vendor} gpu (PCI ID: {self.component_pci_code})"
+        return "unknown gpu"
+
+    def detailed_string(self) -> str:
+        """Returns detailed information about what the Microarch detected"""
+        detail = ""
+
+        for field, value in vars(self).items():
+            if value != "":
+                detail += f"{field}: {value}\n"
+
+        return detail.strip()

--- a/archspec/gpu/gpu_microarch.py
+++ b/archspec/gpu/gpu_microarch.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Defines the GPUMicroarch class, describing a detected GPU microarchitecture."""
 
+from typing import Dict
+
 
 class GPUMicroarch:
     """Specific GPU Microarchitecture"""
@@ -45,6 +47,14 @@ class GPUMicroarch:
         # Only relevant for AMD
         self.gfx_target = gfx_target
 
+    def __eq__(self, other):
+        if not isinstance(other, GPUMicroarch):
+            return NotImplemented
+        return vars(self) == vars(other)
+
+    def __hash__(self) -> int:
+        return hash((self.vendor, self.vendor_pci_code, self.component_pci_code, self.name))
+
     def __repr__(self) -> str:
         fields = ", ".join(
             f"{field}={value!r}" for field, value in vars(self).items() if value != ""
@@ -67,3 +77,30 @@ class GPUMicroarch:
                 detail += f"{field}: {value}\n"
 
         return detail.strip()
+
+    def to_dict(self) -> Dict[str, str]:
+        """Returns a dictionary representation of this object."""
+        return {
+            "name": self.name,
+            "brand_string": self.brand_string,
+            "vendor": self.vendor,
+            "driver_version": self.driver_version,
+            "vendor_pci_code": self.vendor_pci_code,
+            "component_pci_code": self.component_pci_code,
+            "compute_capability": self.compute_capability,
+            "gfx_target": self.gfx_target,
+        }
+
+    @staticmethod
+    def from_dict(data) -> "GPUMicroarch":
+        """Construct a GPU microarchitecture from a dictionary representation."""
+        return GPUMicroarch(
+            name=data.get("name", ""),
+            brand_string=data.get("brand_string", ""),
+            vendor=data.get("vendor", ""),
+            driver_version=data.get("driver_version", ""),
+            vendor_pci_code=data.get("vendor_pci_code", ""),
+            component_pci_code=data.get("component_pci_code", ""),
+            compute_capability=data.get("compute_capability", ""),
+            gfx_target=data.get("gfx_target", ""),
+        )

--- a/archspec/gpu/nvidia.py
+++ b/archspec/gpu/nvidia.py
@@ -8,7 +8,7 @@ import subprocess
 import warnings
 from typing import List, Tuple
 
-from archspec.gpu.gpu_microarch import GPUMicroarch
+from .gpu_microarch import GPUMicroarch
 
 #: Fields queried from nvidia-smi, in output-column order. ``compute_cap`` is
 #: only recognized on newer drivers (~R495+); on older drivers it is dropped

--- a/archspec/gpu/nvidia.py
+++ b/archspec/gpu/nvidia.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Detection of NVIDIA GPUs through the nvidia-smi toolchain."""
 
+import string
 import subprocess
 import warnings
 from typing import List, Tuple
@@ -39,6 +40,12 @@ def _parse_pci_device_id(combined_id: str) -> Tuple[str, str]:
         )
 
     hex_digits = combined_id[2:]
+    if not all(c in string.hexdigits for c in hex_digits):
+        raise ValueError(
+            "invalid PCI device ID: expected 10-character '0x'-prefixed hex"
+            f" string, got {combined_id!r}"
+        )
+
     return (f"0x{hex_digits[:4]}".lower(), f"0x{hex_digits[4:]}".lower())
 
 

--- a/archspec/gpu/nvidia.py
+++ b/archspec/gpu/nvidia.py
@@ -1,0 +1,128 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Detection of NVIDIA GPUs through the nvidia-smi toolchain."""
+
+import subprocess
+import warnings
+from typing import List, Tuple
+
+from archspec.gpu.gpu_microarch import GPUMicroarch
+
+#: Fields queried from nvidia-smi, in output-column order. ``compute_cap`` is
+#: only recognized on newer drivers (~R495+); on older drivers it is dropped
+#: (see ``smi_info``), so it is kept last to keep the leading columns
+#: at stable indices regardless of whether it is present.
+_SMI_BASE_FIELDS = ["gpu_name", "driver_version", "pci.device_id"]
+
+
+def _parse_pci_device_id(combined_id: str) -> Tuple[str, str]:
+    """Parse a combined PCI device ID into (device, vendor) codes.
+
+    Args:
+        combined_id: 10-character hex string from nvidia-smi ``pci.device_id``
+            (e.g. ``0x2C0210DE``).
+
+    Returns:
+        A tuple of ``(component_pci_code, vendor_pci_code)`` in lowercase
+        (e.g. ``("0x2c02", "0x10de")``).
+
+    Raises:
+        ValueError: if *combined_id* is not a valid 10-character hex string
+            with a ``0x`` prefix.
+    """
+    if len(combined_id) != 10 or combined_id[:2] != "0x":
+        raise ValueError(
+            "invalid PCI device ID: expected 10-character '0x'-prefixed hex"
+            f" string, got {combined_id!r}"
+        )
+
+    hex_digits = combined_id[2:]
+    return (f"0x{hex_digits[:4]}".lower(), f"0x{hex_digits[4:]}".lower())
+
+
+def _compute_capability_to_compiler_flag(name: str) -> str:
+    """Transform decimal format compute capability to format expected by compiler flags.
+
+    e.g. 9.0 -> sm_90
+    """
+    # validation
+    if not name:
+        return ""
+
+    if not name[0].isdigit() or "." not in name:
+        return ""
+
+    # parsing
+    parsed_name = name.replace(".", "")
+    parsed_name = f"sm_{parsed_name}"
+
+    return parsed_name
+
+
+def _run_smi(fields: List[str]) -> subprocess.CompletedProcess:
+    """Run nvidia-smi querying the given GPU fields, in CSV format."""
+    return subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-gpu={','.join(fields)}",
+            "--format=csv,noheader",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+
+
+def smi_info() -> List[GPUMicroarch]:
+    """Retrieve info for all NVIDIA GPUs using nvidia-smi."""
+
+    # Try query with compute_cap first, then fall back without it.
+    fields = _SMI_BASE_FIELDS + ["compute_cap"]
+    try:
+        result = _run_smi(fields)
+    except FileNotFoundError:
+        warnings.warn("nvidia-smi is not installed; skipping NVIDIA GPU detection")
+        return []
+    except subprocess.CalledProcessError:
+        # An unrecognized query field (compute_cap on older drivers, ~pre-R495)
+        # fails the whole query, so retry with just the base fields rather than
+        # losing detection entirely.
+        fields = _SMI_BASE_FIELDS
+        try:
+            result = _run_smi(fields)
+        except subprocess.CalledProcessError:
+            return []
+
+    gpus: List[GPUMicroarch] = []
+    for line in result.stdout.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        # parts align positionally with `fields`:
+        # [brand_string, driver_version, combined vendor+device pci code(, compute_cap)]
+        if len(parts) < len(_SMI_BASE_FIELDS):
+            continue
+
+        # Skip this gpu if id parsing is malformed
+        try:
+            pci_codes = _parse_pci_device_id(parts[2])
+        except ValueError as e:
+            warnings.warn(f"skipping NVIDIA GPU: {e}")
+            continue
+
+        compute_capability = (
+            _compute_capability_to_compiler_flag(parts[3]) if len(parts) > 3 else ""
+        )
+        gpus.append(
+            GPUMicroarch(
+                name=compute_capability,
+                vendor="nvidia",
+                brand_string=parts[0],
+                driver_version=parts[1],
+                component_pci_code=pci_codes[0],
+                vendor_pci_code=pci_codes[1],
+                compute_capability=compute_capability,
+            )
+        )
+    return gpus

--- a/archspec/gpu/nvidia.py
+++ b/archspec/gpu/nvidia.py
@@ -52,7 +52,7 @@ def _parse_pci_device_id(combined_id: str) -> Tuple[str, str]:
 def _compute_capability_to_compiler_flag(name: str) -> str:
     """Transform decimal format compute capability to format expected by compiler flags.
 
-    e.g. 9.0 -> sm_90
+    e.g. 9.0 -> 90
     """
     # validation
     if not name:
@@ -63,7 +63,6 @@ def _compute_capability_to_compiler_flag(name: str) -> str:
 
     # parsing
     parsed_name = name.replace(".", "")
-    parsed_name = f"sm_{parsed_name}"
 
     return parsed_name
 

--- a/archspec/gpu/schema.py
+++ b/archspec/gpu/schema.py
@@ -1,0 +1,33 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Global objects with the content of the GPU detection JSON file and its schema"""
+
+import os
+import pathlib
+
+from ..cpu.schema import LazyDictionary, _load
+
+#: Environment variable that might point to a directory with a user defined JSON file
+DIR_FROM_ENVIRONMENT = "ARCHSPEC_GPU_DIR"
+
+
+def _json_file(filename: str, allow_custom: bool = False) -> pathlib.Path:
+    """Given a filename, returns the absolute path for the GPU JSON file.
+
+    Args:
+        filename: filename for the JSON file
+        allow_custom: if True, allows overriding the location where the file resides
+    """
+    json_dir = pathlib.Path(__file__).parent / ".." / "json" / "gpu"
+    if allow_custom and DIR_FROM_ENVIRONMENT in os.environ:
+        json_dir = pathlib.Path(os.environ[DIR_FROM_ENVIRONMENT])
+    return (json_dir / filename).absolute()
+
+
+#: In memory representation of the data in detection.json, loaded on first access
+DETECTION_JSON = LazyDictionary(_load, _json_file("detection.json", allow_custom=True), None)
+
+#: JSON schema for detection.json, loaded on first access
+DETECTION_JSON_SCHEMA = LazyDictionary(_load, _json_file("detection_schema.json"), None)

--- a/docs/source/apidocs.rst
+++ b/docs/source/apidocs.rst
@@ -35,3 +35,52 @@ archspec.cpu.schema
 
 .. automodule:: archspec.cpu.schema
    :members:
+
+------------
+archspec.gpu
+------------
+
+.. automodule:: archspec.gpu
+   :members:
+
+^^^^^^^^^^^^^^^^
+archspec.gpu.amd
+^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.amd
+   :members:
+
+^^^^^^^^^^^^^^^^^^^
+archspec.gpu.detect
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.detect
+   :members:
+
+^^^^^^^^^^^^^^^^^^^^
+archspec.gpu.generic
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.generic
+   :members:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+archspec.gpu.gpu_microarch
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.gpu_microarch
+   :members:
+
+^^^^^^^^^^^^^^^^^^^
+archspec.gpu.nvidia
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.nvidia
+   :members:
+
+^^^^^^^^^^^^^^^^^^^
+archspec.gpu.schema
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: archspec.gpu.schema
+   :members:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,9 @@ import archspec.cpu
 import archspec.cpu.detect
 
 
-@pytest.mark.parametrize("cli_args", [("--help",), ("cpu", "--help"), ("cpu",)])
+@pytest.mark.parametrize(
+    "cli_args", [("--help",), ("cpu", "--help"), ("cpu",), ("gpu", "--help"), ("gpu",)]
+)
 def test_command_run_without_failure(cli_args):
     result = archspec.cli.main(cli_args)
     assert result == 0

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -5,12 +5,24 @@
 import json
 import subprocess
 
+import jsonschema
 import pytest
 
+import archspec.gpu
 import archspec.gpu.amd
 import archspec.gpu.detect
 import archspec.gpu.generic
 import archspec.gpu.nvidia
+import archspec.gpu.schema
+
+
+# --- JSON data ---
+
+
+def test_validate_json_files():
+    jsonschema.validate(
+        archspec.gpu.schema.DETECTION_JSON.data, archspec.gpu.schema.DETECTION_JSON_SCHEMA.data
+    )
 
 
 def make_pci_devices(root, devices):
@@ -108,7 +120,7 @@ def test_nvidia_pci_device_id_parsing(combined, expected):
     assert archspec.gpu.nvidia._parse_pci_device_id(combined) == expected
 
 
-@pytest.mark.parametrize("bad_id", ["0x2C0210", "2C0210DE00", "0xZZZZ10DE0"])
+@pytest.mark.parametrize("bad_id", ["0x2C0210", "2C0210DE00", "0xZZZZ10DE0", "0xZZZZ10DE"])
 def test_nvidia_pci_device_id_invalid(bad_id):
     """Test that a malformed PCI device ID raises ValueError."""
     with pytest.raises(ValueError):
@@ -304,3 +316,70 @@ def test_host_does_not_collapse_identical_gpus(tmp_path, monkeypatch):
 
     assert len(gpus) == 2
     assert all(g.brand_string == "NVIDIA H100" for g in gpus)
+
+
+# --- Python API: GPUMicroarch serialization and equality ---
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {
+            "name": "sm_90",
+            "brand_string": "NVIDIA H100 PCIe",
+            "vendor": "nvidia",
+            "driver_version": "550.54.15",
+            "vendor_pci_code": "0x10de",
+            "component_pci_code": "0x2330",
+            "compute_capability": "sm_90",
+        },
+        {
+            "name": "gfx942",
+            "brand_string": "AMD Instinct MI300A",
+            "vendor": "amd",
+            "driver_version": "6.16.13",
+            "vendor_pci_code": "0x1002",
+            "component_pci_code": "0x74a0",
+            "gfx_target": "gfx942",
+        },
+    ],
+)
+def test_round_trip_dict(kwargs):
+    """A GPUMicroarch survives a round trip through to_dict/from_dict."""
+    gpu = archspec.gpu.GPUMicroarch(**kwargs)
+    assert archspec.gpu.GPUMicroarch.from_dict(gpu.to_dict()) == gpu
+
+
+def test_equality_and_hash():
+    """Equal GPUMicroarch objects compare equal, hash equal, and deduplicate in sets."""
+    kwargs = {
+        "name": "gfx942",
+        "vendor": "amd",
+        "vendor_pci_code": "0x1002",
+        "component_pci_code": "0x74a0",
+    }
+    first = archspec.gpu.GPUMicroarch(**kwargs)
+    second = archspec.gpu.GPUMicroarch(**kwargs)
+    other_driver = archspec.gpu.GPUMicroarch(**kwargs, driver_version="6.16.13")
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert first != other_driver
+    assert first != "gfx942"
+    assert len({first, second}) == 1
+
+
+def test_host_returns_gpu_microarch_objects(tmp_path, monkeypatch):
+    """The public host() entry point yields GPUMicroarch instances."""
+    make_pci_devices(tmp_path, [("0x030000", "0x1002", "0x164e")])
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which())
+    archspec.gpu.detect.host.cache_clear()
+
+    gpus = archspec.gpu.host()
+
+    assert gpus
+    assert all(isinstance(g, archspec.gpu.GPUMicroarch) for g in gpus)
+    assert all(archspec.gpu.GPUMicroarch.from_dict(g.to_dict()) == g for g in gpus)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,303 @@
+# Copyright 2019-2026 Lawrence Livermore National Security, LLC and other
+# Archspec Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import json
+import subprocess
+
+import pytest
+
+import archspec.gpu.detect
+
+
+def make_pci_devices(root, devices):
+    """Create fake sysfs PCI device directories under ``root``.
+
+    Args:
+        root: directory to populate (a ``tmp_path``).
+        devices: iterable of ``(class_code, vendor_id, device_id)`` tuples.
+    """
+    for i, (class_code, vendor_id, device_id) in enumerate(devices):
+        device_dir = root / f"0000:{i:02x}:00.0"
+        device_dir.mkdir()
+        (device_dir / "class").write_text(class_code)
+        (device_dir / "vendor").write_text(vendor_id)
+        (device_dir / "device").write_text(device_id)
+
+
+def mock_smi(stdout, returncode=0):
+    """Return a ``subprocess.run`` replacement that yields the given stdout."""
+
+    def _run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout)
+
+    return _run
+
+
+def mock_which(*installed):
+    """Return a ``shutil.which`` replacement that reports only ``installed`` tools."""
+    return lambda name, *args, **kwargs: f"/usr/bin/{name}" if name in installed else None
+
+
+# --- Stage 1: vendor detection (sysfs scan) ---
+
+
+@pytest.mark.parametrize(
+    "devices,expected",
+    [
+        ([], set()),
+        ([("0x030000", "0x10de", "0x2c02")], {"nvidia"}),
+        ([("0x120000", "0x1002", "0x74a0")], {"amd"}),
+        (
+            [("0x120000", "0x1002", "0x74a0"), ("0x030000", "0x8086", "0x56a0")],
+            {"amd", "intel"},
+        ),
+        (
+            [
+                ("0x030000", "0x10de", "0x2c02"),
+                ("0x120000", "0x1002", "0x74a0"),
+                ("0x030000", "0x8086", "0x56a0"),
+            ],
+            {"nvidia", "amd", "intel"},
+        ),
+        ([("0x010000", "0x10de", "0x2c02")], set()),
+        (
+            [("0x030000", "0x10de", "0x2c02"), ("0x030000", "0x10de", "0x2204")],
+            {"nvidia"},
+        ),
+        ([("0x030000", "0x1234", "0x0001")], set()),
+    ],
+)
+def test_sysfs_scan_detects_vendors(tmp_path, monkeypatch, devices, expected):
+    """Test that the sysfs PCI scan reports exactly the GPU vendors present."""
+    make_pci_devices(tmp_path, devices)
+    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+
+    assert {g.vendor for g in archspec.gpu.detect._scan_sysfs_pci_for_gpus()} == expected
+
+
+def test_detect_amd_instinct_accelerator(tmp_path, monkeypatch):
+    """Test that an AMD Instinct accelerator (PCI class 0x120000) is detected."""
+    device_dir = tmp_path / "0000:c1:00.0"
+    device_dir.mkdir()
+    (device_dir / "class").write_text("0x120000")
+    (device_dir / "vendor").write_text("0x1002")
+    (device_dir / "device").write_text("0x74a0")
+    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+
+    gpus = archspec.gpu.detect._scan_sysfs_pci_for_gpus()
+    assert {g.vendor for g in gpus} == {"amd"}
+    assert gpus[0].component_pci_code == "0x74a0"
+
+
+# --- Stage 2: nvidia-smi parsing ---
+
+
+@pytest.mark.parametrize(
+    "combined,expected",
+    [
+        ("0x2C0210DE", ("0x2c02", "0x10de")),
+        ("0x233010DE", ("0x2330", "0x10de")),
+    ],
+)
+def test_nvidia_pci_device_id_parsing(combined, expected):
+    """Test that a combined PCI device ID splits into lowercase (device, vendor) codes."""
+    assert archspec.gpu.detect._parse_nvidia_pci_device_id(combined) == expected
+
+
+@pytest.mark.parametrize("bad_id", ["0x2C0210", "2C0210DE00", "0xZZZZ10DE0"])
+def test_nvidia_pci_device_id_invalid(bad_id):
+    """Test that a malformed PCI device ID raises ValueError."""
+    with pytest.raises(ValueError):
+        archspec.gpu.detect._parse_nvidia_pci_device_id(bad_id)
+
+
+@pytest.mark.parametrize(
+    "compute_cap,expected",
+    [
+        ("9.0", "sm_90"),
+        ("8.6", "sm_86"),
+        ("7.5", "sm_75"),
+        ("12.0", "sm_120"),  # multi-digit major
+        ("", ""),  # empty
+        ("9", ""),  # no dot / no minor
+        ("x.0", ""),  # non-digit lead
+        ("sm_90", ""),  # already a flag, not decimal input
+    ],
+)
+def test_compute_capability_to_compiler_flag(compute_cap, expected):
+    """Test conversion of decimal compute capability to the sm_XX compiler-flag form."""
+    assert archspec.gpu.detect._compute_capability_to_compiler_flag(compute_cap) == expected
+
+
+def test_nvidia_smi_info_parses_smi_output(monkeypatch):
+    """Test that _nvidia_smi_info parses nvidia-smi CSV output into GPUMicroarch objects."""
+    nvidia_smi_csv = (
+        "NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE, 12.0\n"
+        "NVIDIA H100 PCIe, 550.54.15, 0x233010DE, 9.0\n"
+    )
+    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(nvidia_smi_csv))
+
+    gpus = archspec.gpu.detect._nvidia_smi_info()
+
+    assert len(gpus) == 2
+    assert all(gpu.vendor == "nvidia" for gpu in gpus)
+    assert all(gpu.vendor_pci_code == "0x10de" for gpu in gpus)
+
+    assert gpus[0].brand_string == "NVIDIA GeForce RTX 5080"
+    assert gpus[0].driver_version == "595.58.03"
+    assert gpus[0].component_pci_code == "0x2c02"
+    assert gpus[0].compute_capability == "sm_120"
+    assert gpus[0].name == "sm_120"
+
+    assert gpus[1].brand_string == "NVIDIA H100 PCIe"
+    assert gpus[1].driver_version == "550.54.15"
+    assert gpus[1].component_pci_code == "0x2330"
+    assert gpus[1].compute_capability == "sm_90"
+    assert gpus[1].name == "sm_90"
+
+
+# --- Stage 2: rocm-smi parsing ---
+
+
+def test_rocm_smi_info_parses_rocm_smi_json(monkeypatch):
+    """Test that _rocm_smi_info parses rocm-smi --json output into GPUMicroarch objects."""
+    rocm_smi_json = json.dumps(
+        {
+            "card0": {"Card Series": "AMD Radeon RX 6800 XT", "Device ID": "0x73BF"},
+            "card1": {"Market Name": "AMD Instinct MI250X", "GPU ID": "0x740C"},
+            "system": {"Driver version": "6.7.0"},
+        }
+    )
+    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(rocm_smi_json))
+
+    gpus = archspec.gpu.detect._rocm_smi_info()
+
+    assert len(gpus) == 2
+    assert all(gpu.vendor == "amd" for gpu in gpus)
+    assert all(gpu.vendor_pci_code == "0x1002" for gpu in gpus)
+    assert all(gpu.driver_version == "6.7.0" for gpu in gpus)
+
+    assert gpus[0].brand_string == "AMD Radeon RX 6800 XT"
+    assert gpus[0].component_pci_code == "0x73bf"
+
+    assert gpus[1].brand_string == "AMD Instinct MI250X"
+    assert gpus[1].component_pci_code == "0x740c"
+
+
+def test_rocm_smi_info_parses_real_mi300a_output(monkeypatch):
+    """Test _rocm_smi_info against real rocm-smi output from a 4x MI300A machine."""
+    rocm_smi_json = (
+        '{"card0": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
+        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "46363", '
+        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
+        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
+        '"Node ID": "4", "GFX Version": "gfx942"}, '
+        '"card1": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
+        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "46186", '
+        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
+        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
+        '"Node ID": "5", "GFX Version": "gfx942"}, '
+        '"card2": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
+        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "58426", '
+        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
+        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
+        '"Node ID": "6", "GFX Version": "gfx942"}, '
+        '"card3": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
+        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "5131", '
+        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
+        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
+        '"Node ID": "7", "GFX Version": "gfx942"}, '
+        '"system": {"Driver version": "6.16.13"}}'
+    )
+    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(rocm_smi_json))
+
+    gpus = archspec.gpu.detect._rocm_smi_info()
+
+    assert len(gpus) == 4
+    for gpu in gpus:
+        assert gpu.vendor == "amd"
+        assert gpu.vendor_pci_code == "0x1002"
+        assert gpu.driver_version == "6.16.13"
+        assert gpu.brand_string == "AMD Instinct MI300A"
+        assert gpu.component_pci_code == "0x74a0"
+        assert gpu.gfx_target == "gfx942"
+        assert gpu.name == "gfx942"
+
+
+def test_rocm_smi_info_handles_malformed_json(monkeypatch):
+    """Test that _rocm_smi_info returns no GPUs when rocm-smi emits unparseable output."""
+    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi("not json"))
+
+    assert archspec.gpu.detect._rocm_smi_info() == []
+
+
+# --- Pipeline: host() merges SMI and sysfs sources ---
+
+
+def test_host_detects_gpu_visible_only_to_smi(tmp_path, monkeypatch):
+    """WSL case: a GPU absent from sysfs is still detected via an installed SMI tool."""
+    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
+    monkeypatch.setattr(
+        archspec.gpu.detect.subprocess,
+        "run",
+        mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
+    )
+    archspec.gpu.detect.host.cache_clear()
+
+    gpus = archspec.gpu.detect.host()
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "nvidia"
+    assert gpus[0].driver_version == "595.58.03"
+
+
+def test_host_keeps_sysfs_gpu_no_smi_describes(tmp_path, monkeypatch):
+    """iGPU case: an AMD device sysfs sees but rocm-smi cannot is still reported,
+    alongside the nvidia-smi-enriched NVIDIA card, without duplication."""
+    make_pci_devices(
+        tmp_path,
+        [("0x030000", "0x10de", "0x2c02"), ("0x030000", "0x1002", "0x164e")],
+    )
+    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
+    monkeypatch.setattr(
+        archspec.gpu.detect.subprocess,
+        "run",
+        mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
+    )
+    archspec.gpu.detect.host.cache_clear()
+
+    gpus = archspec.gpu.detect.host()
+    by_vendor = {g.vendor: g for g in gpus}
+
+    assert len(gpus) == 2
+    assert by_vendor["nvidia"].driver_version == "595.58.03"
+    assert by_vendor["amd"].component_pci_code == "0x164e"
+    assert by_vendor["amd"].driver_version == ""
+
+
+def test_host_does_not_collapse_identical_gpus(tmp_path, monkeypatch):
+    """Identical cards reported by an SMI tool are all kept, and sysfs duplicates of
+    the same model do not double-count them."""
+    make_pci_devices(
+        tmp_path,
+        [("0x030000", "0x10de", "0x2330"), ("0x030000", "0x10de", "0x2330")],
+    )
+    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
+    monkeypatch.setattr(
+        archspec.gpu.detect.subprocess,
+        "run",
+        mock_smi("NVIDIA H100, 550.54.15, 0x233010DE\nNVIDIA H100, 550.54.15, 0x233010DE\n"),
+    )
+    archspec.gpu.detect.host.cache_clear()
+
+    gpus = archspec.gpu.detect.host()
+
+    assert len(gpus) == 2
+    assert all(g.brand_string == "NVIDIA H100" for g in gpus)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -7,7 +7,10 @@ import subprocess
 
 import pytest
 
+import archspec.gpu.amd
 import archspec.gpu.detect
+import archspec.gpu.generic
+import archspec.gpu.nvidia
 
 
 def make_pci_devices(root, devices):
@@ -71,9 +74,9 @@ def mock_which(*installed):
 def test_sysfs_scan_detects_vendors(tmp_path, monkeypatch, devices, expected):
     """Test that the sysfs PCI scan reports exactly the GPU vendors present."""
     make_pci_devices(tmp_path, devices)
-    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
 
-    assert {g.vendor for g in archspec.gpu.detect._scan_sysfs_pci_for_gpus()} == expected
+    assert {g.vendor for g in archspec.gpu.generic.scan_sysfs_pci_for_gpus()} == expected
 
 
 def test_detect_amd_instinct_accelerator(tmp_path, monkeypatch):
@@ -83,9 +86,9 @@ def test_detect_amd_instinct_accelerator(tmp_path, monkeypatch):
     (device_dir / "class").write_text("0x120000")
     (device_dir / "vendor").write_text("0x1002")
     (device_dir / "device").write_text("0x74a0")
-    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
 
-    gpus = archspec.gpu.detect._scan_sysfs_pci_for_gpus()
+    gpus = archspec.gpu.generic.scan_sysfs_pci_for_gpus()
     assert {g.vendor for g in gpus} == {"amd"}
     assert gpus[0].component_pci_code == "0x74a0"
 
@@ -102,14 +105,14 @@ def test_detect_amd_instinct_accelerator(tmp_path, monkeypatch):
 )
 def test_nvidia_pci_device_id_parsing(combined, expected):
     """Test that a combined PCI device ID splits into lowercase (device, vendor) codes."""
-    assert archspec.gpu.detect._parse_nvidia_pci_device_id(combined) == expected
+    assert archspec.gpu.nvidia._parse_pci_device_id(combined) == expected
 
 
 @pytest.mark.parametrize("bad_id", ["0x2C0210", "2C0210DE00", "0xZZZZ10DE0"])
 def test_nvidia_pci_device_id_invalid(bad_id):
     """Test that a malformed PCI device ID raises ValueError."""
     with pytest.raises(ValueError):
-        archspec.gpu.detect._parse_nvidia_pci_device_id(bad_id)
+        archspec.gpu.nvidia._parse_pci_device_id(bad_id)
 
 
 @pytest.mark.parametrize(
@@ -127,18 +130,18 @@ def test_nvidia_pci_device_id_invalid(bad_id):
 )
 def test_compute_capability_to_compiler_flag(compute_cap, expected):
     """Test conversion of decimal compute capability to the sm_XX compiler-flag form."""
-    assert archspec.gpu.detect._compute_capability_to_compiler_flag(compute_cap) == expected
+    assert archspec.gpu.nvidia._compute_capability_to_compiler_flag(compute_cap) == expected
 
 
 def test_nvidia_smi_info_parses_smi_output(monkeypatch):
-    """Test that _nvidia_smi_info parses nvidia-smi CSV output into GPUMicroarch objects."""
+    """Test that nvidia.smi_info parses nvidia-smi CSV output into GPUMicroarch objects."""
     nvidia_smi_csv = (
         "NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE, 12.0\n"
         "NVIDIA H100 PCIe, 550.54.15, 0x233010DE, 9.0\n"
     )
-    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(nvidia_smi_csv))
+    monkeypatch.setattr(archspec.gpu.nvidia.subprocess, "run", mock_smi(nvidia_smi_csv))
 
-    gpus = archspec.gpu.detect._nvidia_smi_info()
+    gpus = archspec.gpu.nvidia.smi_info()
 
     assert len(gpus) == 2
     assert all(gpu.vendor == "nvidia" for gpu in gpus)
@@ -161,7 +164,7 @@ def test_nvidia_smi_info_parses_smi_output(monkeypatch):
 
 
 def test_rocm_smi_info_parses_rocm_smi_json(monkeypatch):
-    """Test that _rocm_smi_info parses rocm-smi --json output into GPUMicroarch objects."""
+    """Test that amd.smi_info parses rocm-smi --json output into GPUMicroarch objects."""
     rocm_smi_json = json.dumps(
         {
             "card0": {"Card Series": "AMD Radeon RX 6800 XT", "Device ID": "0x73BF"},
@@ -169,9 +172,9 @@ def test_rocm_smi_info_parses_rocm_smi_json(monkeypatch):
             "system": {"Driver version": "6.7.0"},
         }
     )
-    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(rocm_smi_json))
+    monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi(rocm_smi_json))
 
-    gpus = archspec.gpu.detect._rocm_smi_info()
+    gpus = archspec.gpu.amd.smi_info()
 
     assert len(gpus) == 2
     assert all(gpu.vendor == "amd" for gpu in gpus)
@@ -186,7 +189,7 @@ def test_rocm_smi_info_parses_rocm_smi_json(monkeypatch):
 
 
 def test_rocm_smi_info_parses_real_mi300a_output(monkeypatch):
-    """Test _rocm_smi_info against real rocm-smi output from a 4x MI300A machine."""
+    """Test amd.smi_info against real rocm-smi output from a 4x MI300A machine."""
     rocm_smi_json = (
         '{"card0": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
         '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "46363", '
@@ -210,9 +213,9 @@ def test_rocm_smi_info_parses_real_mi300a_output(monkeypatch):
         '"Node ID": "7", "GFX Version": "gfx942"}, '
         '"system": {"Driver version": "6.16.13"}}'
     )
-    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi(rocm_smi_json))
+    monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi(rocm_smi_json))
 
-    gpus = archspec.gpu.detect._rocm_smi_info()
+    gpus = archspec.gpu.amd.smi_info()
 
     assert len(gpus) == 4
     for gpu in gpus:
@@ -226,10 +229,10 @@ def test_rocm_smi_info_parses_real_mi300a_output(monkeypatch):
 
 
 def test_rocm_smi_info_handles_malformed_json(monkeypatch):
-    """Test that _rocm_smi_info returns no GPUs when rocm-smi emits unparseable output."""
-    monkeypatch.setattr(archspec.gpu.detect.subprocess, "run", mock_smi("not json"))
+    """Test that amd.smi_info returns no GPUs when rocm-smi emits unparseable output."""
+    monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi("not json"))
 
-    assert archspec.gpu.detect._rocm_smi_info() == []
+    assert archspec.gpu.amd.smi_info() == []
 
 
 # --- Pipeline: host() merges SMI and sysfs sources ---
@@ -237,11 +240,11 @@ def test_rocm_smi_info_handles_malformed_json(monkeypatch):
 
 def test_host_detects_gpu_visible_only_to_smi(tmp_path, monkeypatch):
     """WSL case: a GPU absent from sysfs is still detected via an installed SMI tool."""
-    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
     monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
     monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
     monkeypatch.setattr(
-        archspec.gpu.detect.subprocess,
+        archspec.gpu.nvidia.subprocess,
         "run",
         mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
     )
@@ -261,11 +264,11 @@ def test_host_keeps_sysfs_gpu_no_smi_describes(tmp_path, monkeypatch):
         tmp_path,
         [("0x030000", "0x10de", "0x2c02"), ("0x030000", "0x1002", "0x164e")],
     )
-    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
     monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
     monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
     monkeypatch.setattr(
-        archspec.gpu.detect.subprocess,
+        archspec.gpu.nvidia.subprocess,
         "run",
         mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
     )
@@ -287,11 +290,11 @@ def test_host_does_not_collapse_identical_gpus(tmp_path, monkeypatch):
         tmp_path,
         [("0x030000", "0x10de", "0x2330"), ("0x030000", "0x10de", "0x2330")],
     )
-    monkeypatch.setattr(archspec.gpu.detect, "SYSFS_PCI_DEVICES", str(tmp_path))
+    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
     monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
     monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
     monkeypatch.setattr(
-        archspec.gpu.detect.subprocess,
+        archspec.gpu.nvidia.subprocess,
         "run",
         mock_smi("NVIDIA H100, 550.54.15, 0x233010DE\nNVIDIA H100, 550.54.15, 0x233010DE\n"),
     )

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -2,42 +2,13 @@
 # Archspec Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import json
 import subprocess
 
-import jsonschema
 import pytest
 
 import archspec.gpu
 import archspec.gpu.amd
-import archspec.gpu.detect
-import archspec.gpu.generic
 import archspec.gpu.nvidia
-import archspec.gpu.schema
-
-
-# --- JSON data ---
-
-
-def test_validate_json_files():
-    jsonschema.validate(
-        archspec.gpu.schema.DETECTION_JSON.data, archspec.gpu.schema.DETECTION_JSON_SCHEMA.data
-    )
-
-
-def make_pci_devices(root, devices):
-    """Create fake sysfs PCI device directories under ``root``.
-
-    Args:
-        root: directory to populate (a ``tmp_path``).
-        devices: iterable of ``(class_code, vendor_id, device_id)`` tuples.
-    """
-    for i, (class_code, vendor_id, device_id) in enumerate(devices):
-        device_dir = root / f"0000:{i:02x}:00.0"
-        device_dir.mkdir()
-        (device_dir / "class").write_text(class_code)
-        (device_dir / "vendor").write_text(vendor_id)
-        (device_dir / "device").write_text(device_id)
 
 
 def mock_smi(stdout, returncode=0):
@@ -47,62 +18,6 @@ def mock_smi(stdout, returncode=0):
         return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout)
 
     return _run
-
-
-def mock_which(*installed):
-    """Return a ``shutil.which`` replacement that reports only ``installed`` tools."""
-    return lambda name, *args, **kwargs: f"/usr/bin/{name}" if name in installed else None
-
-
-# --- Stage 1: vendor detection (sysfs scan) ---
-
-
-@pytest.mark.parametrize(
-    "devices,expected",
-    [
-        ([], set()),
-        ([("0x030000", "0x10de", "0x2c02")], {"nvidia"}),
-        ([("0x120000", "0x1002", "0x74a0")], {"amd"}),
-        (
-            [("0x120000", "0x1002", "0x74a0"), ("0x030000", "0x8086", "0x56a0")],
-            {"amd", "intel"},
-        ),
-        (
-            [
-                ("0x030000", "0x10de", "0x2c02"),
-                ("0x120000", "0x1002", "0x74a0"),
-                ("0x030000", "0x8086", "0x56a0"),
-            ],
-            {"nvidia", "amd", "intel"},
-        ),
-        ([("0x010000", "0x10de", "0x2c02")], set()),
-        (
-            [("0x030000", "0x10de", "0x2c02"), ("0x030000", "0x10de", "0x2204")],
-            {"nvidia"},
-        ),
-        ([("0x030000", "0x1234", "0x0001")], set()),
-    ],
-)
-def test_sysfs_scan_detects_vendors(tmp_path, monkeypatch, devices, expected):
-    """Test that the sysfs PCI scan reports exactly the GPU vendors present."""
-    make_pci_devices(tmp_path, devices)
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-
-    assert {g.vendor for g in archspec.gpu.generic.scan_sysfs_pci_for_gpus()} == expected
-
-
-def test_detect_amd_instinct_accelerator(tmp_path, monkeypatch):
-    """Test that an AMD Instinct accelerator (PCI class 0x120000) is detected."""
-    device_dir = tmp_path / "0000:c1:00.0"
-    device_dir.mkdir()
-    (device_dir / "class").write_text("0x120000")
-    (device_dir / "vendor").write_text("0x1002")
-    (device_dir / "device").write_text("0x74a0")
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-
-    gpus = archspec.gpu.generic.scan_sysfs_pci_for_gpus()
-    assert {g.vendor for g in gpus} == {"amd"}
-    assert gpus[0].component_pci_code == "0x74a0"
 
 
 # --- Stage 2: nvidia-smi parsing ---
@@ -175,147 +90,11 @@ def test_nvidia_smi_info_parses_smi_output(monkeypatch):
 # --- Stage 2: rocm-smi parsing ---
 
 
-def test_rocm_smi_info_parses_rocm_smi_json(monkeypatch):
-    """Test that amd.smi_info parses rocm-smi --json output into GPUMicroarch objects."""
-    rocm_smi_json = json.dumps(
-        {
-            "card0": {"Card Series": "AMD Radeon RX 6800 XT", "Device ID": "0x73BF"},
-            "card1": {"Market Name": "AMD Instinct MI250X", "GPU ID": "0x740C"},
-            "system": {"Driver version": "6.7.0"},
-        }
-    )
-    monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi(rocm_smi_json))
-
-    gpus = archspec.gpu.amd.smi_info()
-
-    assert len(gpus) == 2
-    assert all(gpu.vendor == "amd" for gpu in gpus)
-    assert all(gpu.vendor_pci_code == "0x1002" for gpu in gpus)
-    assert all(gpu.driver_version == "6.7.0" for gpu in gpus)
-
-    assert gpus[0].brand_string == "AMD Radeon RX 6800 XT"
-    assert gpus[0].component_pci_code == "0x73bf"
-
-    assert gpus[1].brand_string == "AMD Instinct MI250X"
-    assert gpus[1].component_pci_code == "0x740c"
-
-
-def test_rocm_smi_info_parses_real_mi300a_output(monkeypatch):
-    """Test amd.smi_info against real rocm-smi output from a 4x MI300A machine."""
-    rocm_smi_json = (
-        '{"card0": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
-        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "46363", '
-        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
-        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
-        '"Node ID": "4", "GFX Version": "gfx942"}, '
-        '"card1": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
-        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "46186", '
-        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
-        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
-        '"Node ID": "5", "GFX Version": "gfx942"}, '
-        '"card2": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
-        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "58426", '
-        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
-        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
-        '"Node ID": "6", "GFX Version": "gfx942"}, '
-        '"card3": {"Device Name": "AMD Instinct MI300A", "Device ID": "0x74a0", '
-        '"Device Rev": "0x00", "Subsystem ID": "0x74a0", "GUID": "5131", '
-        '"Card Series": "AMD Instinct MI300A", "Card Model": "0x74a0", '
-        '"Card Vendor": "Advanced Micro Devices, Inc. [AMD/ATI]", "Card SKU": "N/A", '
-        '"Node ID": "7", "GFX Version": "gfx942"}, '
-        '"system": {"Driver version": "6.16.13"}}'
-    )
-    monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi(rocm_smi_json))
-
-    gpus = archspec.gpu.amd.smi_info()
-
-    assert len(gpus) == 4
-    for gpu in gpus:
-        assert gpu.vendor == "amd"
-        assert gpu.vendor_pci_code == "0x1002"
-        assert gpu.driver_version == "6.16.13"
-        assert gpu.brand_string == "AMD Instinct MI300A"
-        assert gpu.component_pci_code == "0x74a0"
-        assert gpu.gfx_target == "gfx942"
-        assert gpu.name == "gfx942"
-
-
 def test_rocm_smi_info_handles_malformed_json(monkeypatch):
     """Test that amd.smi_info returns no GPUs when rocm-smi emits unparseable output."""
     monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi("not json"))
 
     assert archspec.gpu.amd.smi_info() == []
-
-
-# --- Pipeline: host() merges SMI and sysfs sources ---
-
-
-def test_host_detects_gpu_visible_only_to_smi(tmp_path, monkeypatch):
-    """WSL case: a GPU absent from sysfs is still detected via an installed SMI tool."""
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
-    monkeypatch.setattr(
-        archspec.gpu.nvidia.subprocess,
-        "run",
-        mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
-    )
-    archspec.gpu.detect.host.cache_clear()
-
-    gpus = archspec.gpu.detect.host()
-
-    assert len(gpus) == 1
-    assert gpus[0].vendor == "nvidia"
-    assert gpus[0].driver_version == "595.58.03"
-
-
-def test_host_keeps_sysfs_gpu_no_smi_describes(tmp_path, monkeypatch):
-    """iGPU case: an AMD device sysfs sees but rocm-smi cannot is still reported,
-    alongside the nvidia-smi-enriched NVIDIA card, without duplication."""
-    make_pci_devices(
-        tmp_path,
-        [("0x030000", "0x10de", "0x2c02"), ("0x030000", "0x1002", "0x164e")],
-    )
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
-    monkeypatch.setattr(
-        archspec.gpu.nvidia.subprocess,
-        "run",
-        mock_smi("NVIDIA GeForce RTX 5080, 595.58.03, 0x2C0210DE\n"),
-    )
-    archspec.gpu.detect.host.cache_clear()
-
-    gpus = archspec.gpu.detect.host()
-    by_vendor = {g.vendor: g for g in gpus}
-
-    assert len(gpus) == 2
-    assert by_vendor["nvidia"].driver_version == "595.58.03"
-    assert by_vendor["amd"].component_pci_code == "0x164e"
-    assert by_vendor["amd"].driver_version == ""
-
-
-def test_host_does_not_collapse_identical_gpus(tmp_path, monkeypatch):
-    """Identical cards reported by an SMI tool are all kept, and sysfs duplicates of
-    the same model do not double-count them."""
-    make_pci_devices(
-        tmp_path,
-        [("0x030000", "0x10de", "0x2330"), ("0x030000", "0x10de", "0x2330")],
-    )
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which("nvidia-smi"))
-    monkeypatch.setattr(
-        archspec.gpu.nvidia.subprocess,
-        "run",
-        mock_smi("NVIDIA H100, 550.54.15, 0x233010DE\nNVIDIA H100, 550.54.15, 0x233010DE\n"),
-    )
-    archspec.gpu.detect.host.cache_clear()
-
-    gpus = archspec.gpu.detect.host()
-
-    assert len(gpus) == 2
-    assert all(g.brand_string == "NVIDIA H100" for g in gpus)
 
 
 # --- Python API: GPUMicroarch serialization and equality ---
@@ -368,18 +147,3 @@ def test_equality_and_hash():
     assert first != other_driver
     assert first != "gfx942"
     assert len({first, second}) == 1
-
-
-def test_host_returns_gpu_microarch_objects(tmp_path, monkeypatch):
-    """The public host() entry point yields GPUMicroarch instances."""
-    make_pci_devices(tmp_path, [("0x030000", "0x1002", "0x164e")])
-    monkeypatch.setattr(archspec.gpu.generic, "SYSFS_PCI_DEVICES", str(tmp_path))
-    monkeypatch.setattr(archspec.gpu.detect.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(archspec.gpu.detect.shutil, "which", mock_which())
-    archspec.gpu.detect.host.cache_clear()
-
-    gpus = archspec.gpu.host()
-
-    assert gpus
-    assert all(isinstance(g, archspec.gpu.GPUMicroarch) for g in gpus)
-    assert all(archspec.gpu.GPUMicroarch.from_dict(g.to_dict()) == g for g in gpus)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -130,18 +130,18 @@ def test_nvidia_pci_device_id_invalid(bad_id):
 @pytest.mark.parametrize(
     "compute_cap,expected",
     [
-        ("9.0", "sm_90"),
-        ("8.6", "sm_86"),
-        ("7.5", "sm_75"),
-        ("12.0", "sm_120"),  # multi-digit major
+        ("9.0", "90"),
+        ("8.6", "86"),
+        ("7.5", "75"),
+        ("12.0", "120"),  # multi-digit major
         ("", ""),  # empty
         ("9", ""),  # no dot / no minor
         ("x.0", ""),  # non-digit lead
-        ("sm_90", ""),  # already a flag, not decimal input
+        ("90", ""),  # already a flag, not decimal input
     ],
 )
 def test_compute_capability_to_compiler_flag(compute_cap, expected):
-    """Test conversion of decimal compute capability to the sm_XX compiler-flag form."""
+    """Test conversion of decimal compute capability to the XX compiler-flag form."""
     assert archspec.gpu.nvidia._compute_capability_to_compiler_flag(compute_cap) == expected
 
 
@@ -162,14 +162,14 @@ def test_nvidia_smi_info_parses_smi_output(monkeypatch):
     assert gpus[0].brand_string == "NVIDIA GeForce RTX 5080"
     assert gpus[0].driver_version == "595.58.03"
     assert gpus[0].component_pci_code == "0x2c02"
-    assert gpus[0].compute_capability == "sm_120"
-    assert gpus[0].name == "sm_120"
+    assert gpus[0].compute_capability == "120"
+    assert gpus[0].name == "120"
 
     assert gpus[1].brand_string == "NVIDIA H100 PCIe"
     assert gpus[1].driver_version == "550.54.15"
     assert gpus[1].component_pci_code == "0x2330"
-    assert gpus[1].compute_capability == "sm_90"
-    assert gpus[1].name == "sm_90"
+    assert gpus[1].compute_capability == "90"
+    assert gpus[1].name == "90"
 
 
 # --- Stage 2: rocm-smi parsing ---
@@ -326,13 +326,13 @@ def test_host_does_not_collapse_identical_gpus(tmp_path, monkeypatch):
     [
         {},
         {
-            "name": "sm_90",
+            "name": "90",
             "brand_string": "NVIDIA H100 PCIe",
             "vendor": "nvidia",
             "driver_version": "550.54.15",
             "vendor_pci_code": "0x10de",
             "component_pci_code": "0x2330",
-            "compute_capability": "sm_90",
+            "compute_capability": "90",
         },
         {
             "name": "gfx942",

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -20,9 +20,6 @@ def mock_smi(stdout, returncode=0):
     return _run
 
 
-# --- Stage 2: nvidia-smi parsing ---
-
-
 @pytest.mark.parametrize(
     "combined,expected",
     [
@@ -87,17 +84,11 @@ def test_nvidia_smi_info_parses_smi_output(monkeypatch):
     assert gpus[1].name == "90"
 
 
-# --- Stage 2: rocm-smi parsing ---
-
-
 def test_rocm_smi_info_handles_malformed_json(monkeypatch):
     """Test that amd.smi_info returns no GPUs when rocm-smi emits unparseable output."""
     monkeypatch.setattr(archspec.gpu.amd.subprocess, "run", mock_smi("not json"))
 
     assert archspec.gpu.amd.smi_info() == []
-
-
-# --- Python API: GPUMicroarch serialization and equality ---
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Blocked on [archspec-json #163](https://github.com/archspec/archspec-json/pull/163)

Implements SMI-based detection and resolution to compatibility flag for most modern AMD and NVIDIA GPUs in Linux environments. Adds `gpu` subcommand to archspec CLI to perform two levels of GPU detection (default and verbose). Pins updated version of archspec-json for GPU-related constants and introduces preliminary API support.

### Best effort disclaimer
GPU detection makes a best effort to resolve compatibility identifiers based on available information provided from vendor SMI tools. These changes make no guarantee that detected GPUs will be resolvable to a compatibility identifier if the system's GPU toolchain is broken, the vendor smi tools are not present, the GPU driver version does not match the smi tool's expected version, or the GPUs are no longer supported by current smi tools.