### PR TITLE
Add arrowlake-s and ancestors

### DIFF
--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -70,6 +70,8 @@ from archspec.cpu import Microarchitecture
         "linux-debian13-x60",
         "linux-ubuntu22.04-ampere1",
         "linux-ubuntu22.04-ampere1a",
+        "linux-ubuntu24.04-alderlake",
+        "linux-ubuntu26.04-arrowlake_s",
     ]
 )
 def expected_target(request, monkeypatch):


### PR DESCRIPTION
This commit adds 3 new microarchitectures to the JSON database. Compiler knowledge for them is currently limited to GCC and Clang.

The ubuntu 26.04 tests is "synthetic" and constructed based on the alderlake test (where the kernel is too old to expose all the features).