### PR TITLE
ci: drop jobs on Python 3.8

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
         python-version: |
-          3.8
           3.9
           3.10
           3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = false
 isolated_build = true
-envlist = py38, py39, py310, py311, py312, py313, py314, pylint, flake8, black, isort, mypy, vermin
+envlist = py39, py310, py311, py312, py313, py314, pylint, flake8, black, isort, mypy, vermin
 
 [gh]
 python =
@@ -11,8 +11,6 @@ python =
     3.11: py311
     3.10: py310
     3.9: py39
-    3.8: py38
-    3.7: py37
 
 [testenv]
 description = Runs unit tests with coverage


### PR DESCRIPTION
packaging 26.3 (2026-08-04) dropped 3.8 support and switched tags.py to collections.abc.Sequence, which is not subscriptable before 3.9.

This causes failures like:

https://github.com/archspec/archspec/actions/runs/31160154189/job/92808424155?pr=248